### PR TITLE
Dark theme toggle

### DIFF
--- a/extensions/8bitgentleman/dark-theme-toggle.json
+++ b/extensions/8bitgentleman/dark-theme-toggle.json
@@ -2,7 +2,10 @@
     "name": "CSS Dark Mode Toggle",
     "short_description": "Adds a button to the topbar to toggle a theme's dark mode manually. CSS NOT INCLUDED",
     "author": "Matt Vogel",
+    "tags": ["topbar", "button", "CSS"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-dark-toggle",
     "source_repo": "https://github.com/8bitgentleman/roam-depo-dark-toggle.git",
-    "source_commit": "1e09f12c85451aa3dbf4d3ed7437b7037154243a"
+    "source_commit": "1e09f12c85451aa3dbf4d3ed7437b7037154243a",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+
 }

--- a/extensions/8bitgentleman/dark-theme-toggle.json
+++ b/extensions/8bitgentleman/dark-theme-toggle.json
@@ -1,0 +1,8 @@
+{
+    "name": "CSS Dark Mode Toggle",
+    "short_description": "Adds a button to the topbar to toggle a theme's dark mode manually. CSS NOT INCLUDED",
+    "author": "Matt Vogel",
+    "source_url": "https://github.com/8bitgentleman/roam-depo-dark-toggle",
+    "source_repo": "https://github.com/8bitgentleman/roam-depo-dark-toggle.git",
+    "source_commit": "1e09f12c85451aa3dbf4d3ed7437b7037154243a"
+}


### PR DESCRIPTION
This extension adds a button to the topbar to allow toggling of custom CSS modes. It works by adding and removing the css class `.rm-dark-theme` from the document body.
Custom theme maintainers (or the adventurous) can add support for this in several ways but I recommend using `:root` variables.

```
:root{
	//REGULAR THEME COLOR VARIABLES
}
:root .rm-dark-theme {
	//DARK MODE COLOR THEME VARIABLES
}
```
