### PR TITLE
Clear-sidebar button

### DIFF
--- a/extensions/8bitgentleman/clear-sidebar.json
+++ b/extensions/8bitgentleman/clear-sidebar.json
@@ -1,0 +1,11 @@
+{
+    "name": "Clear Right Sidebar",
+    "short_description": "Adds a button to the top of the right sidebar to clear and close all blocks and pages in the sidebar.",
+    "author": "Matt Vogel",
+    "tags": ["right sidebar", "button"],
+    "source_url": "https://github.com/8bitgentleman/roam-depot-clear-sidebar",
+    "source_repo": "https://github.com/8bitgentleman/roam-depot-clear-sidebar.git",
+    "source_commit": "4972e40f7085a297f67762c190dcf7f928f8a586",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+
+}

--- a/extensions/8bitgentleman/clear-sidebar.json
+++ b/extensions/8bitgentleman/clear-sidebar.json
@@ -5,7 +5,7 @@
     "tags": ["right sidebar", "button"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-clear-sidebar",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-clear-sidebar.git",
-    "source_commit": "4972e40f7085a297f67762c190dcf7f928f8a586",
+    "source_commit": "0d50982067f182d087965482dfcb2dc24ac62682",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Adds a button to the top of the right sidebar to clear and close all blocks and pages in the sidebar. Not 100% sure about the styling but it looks find in vanilla roam.