### PR TITLE
ptn-roam-depot

### DIFF
--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "76b9f47ef05434dfec82dbbb35bd31b0baea78f7",
+  "source_commit": "19d2af2bc976d0fe292bebf53f5aaf69a4a45728",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "19d2af2bc976d0fe292bebf53f5aaf69a4a45728",
+  "source_commit": "39ee1ccd1e60f71fb51221f2e1c965cf68c04173",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "39ee1ccd1e60f71fb51221f2e1c965cf68c04173",
+  "source_commit": "64d85e9877a26db73ed7298640f960e979574f04",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -1,0 +1,10 @@
+{
+  "name": "phonetonote",
+  "short_description": "mobile quick capture as a service",
+  "author": "scott block",
+  "tags": ["phonetonote", "ptn"],
+  "source_url": "https://github.com/phonetonote/ptn-roam-depot",
+  "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
+  "source_commit": "76b9f47ef05434dfec82dbbb35bd31b0baea78f7",
+  "stripe_account": "acct_1LKwanQVF0QOKIg5"
+}


### PR DESCRIPTION
my repo (https://github.com/phonetonote/ptn-roam-depot) has the extension built, but can also be rebuilt with the `build.sh` script.

the code is mostly the existing phone-to-roam-client (https://github.com/phonetonote/phone-to-roam-client/), but I removed old dependencies, and made an onboarding flow for new and existing users.