### PR TITLE
Tweet Extract

### DIFF
--- a/extensions/8bitgentleman/tweet-extractor.json
+++ b/extensions/8bitgentleman/tweet-extractor.json
@@ -5,7 +5,7 @@
     "tags": ["twitter"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-tweet-extract",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-tweet-extract.git",
-    "source_commit": "4cba6978305ceb6dd59c8b2f13a4646e35327832",
+    "source_commit": "a6504d3295ebe1355b2b71d655cc4d4e230bee68",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }

--- a/extensions/8bitgentleman/tweet-extractor.json
+++ b/extensions/8bitgentleman/tweet-extractor.json
@@ -1,0 +1,11 @@
+{
+    "name": "Tweet Extractor",
+    "short_description": "Extracts text and metadata from a tweet saved in your graph.",
+    "author": "Matt Vogel",
+    "tags": ["twitter"],
+    "source_url": "https://github.com/8bitgentleman/roam-depot-tweet-extract",
+    "source_repo": "https://github.com/8bitgentleman/roam-depot-tweet-extract.git",
+    "source_commit": "fd7f4fbe32ac6f367c17ce3eb1cf904dcd89d197",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+
+}

--- a/extensions/8bitgentleman/tweet-extractor.json
+++ b/extensions/8bitgentleman/tweet-extractor.json
@@ -1,11 +1,11 @@
 {
-    "name": "Tweet Extractor",
+    "name": "Tweet Extract",
     "short_description": "Extracts text and metadata from a tweet saved in your graph.",
     "author": "Matt Vogel",
     "tags": ["twitter"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-tweet-extract",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-tweet-extract.git",
-    "source_commit": "fd7f4fbe32ac6f367c17ce3eb1cf904dcd89d197",
+    "source_commit": "4cba6978305ceb6dd59c8b2f13a4646e35327832",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Roam Research Plugin to extract saved tweet text and metadata into your graph. 

  To set up the format of your extracted tweet a simple template system is included, found in the Roam Depot plugin settings panel. For each supported `{OPTION}` the variable will be replaced with the extracted tweet information.

  Options available to the template are `{TWEET}`, `{URL}`, `{AUTHOR_NAME}`, `{AUTHOR_URL}`, `{DATE}`, `{NEWLINE}`.  A default temlpate is included.

  `[[>]] {TWEET} {NEWLINE} [🐦]({URL}) by {AUTHOR_NAME} on [[{DATE}]]`
  


  To trigger the tweet extraction you have two options: Right click plugin or keyboard shortcut

  To trigger via a keyboard shortcut click into the block and hit a `CTRL` + `SHIFT` + `E`. (will be remapable once that is exposed via the extension API)

## Example 
  <img src="https://github.com/8bitgentleman/roam-depot-tweet-extract/raw/main/example.gif" max-width="400"></img>
  
        
