### PR TITLE
hide-left-sidebar-buttons

### DIFF
--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -1,0 +1,10 @@
+{
+    "name": "Hide/Show Left Sidebar Buttons",
+    "short_description": "Roam Research plugin to hide/show the individual buttons in the left sidebar",
+    "author": "Matt Vogel",
+    "tags": ["left sidebar"],
+    "source_url": "https://github.com/8bitgentleman/hide-left-sidebar-buttons",
+    "source_repo": "https://github.com/8bitgentleman/hide-left-sidebar-buttons.git",
+    "source_commit": "ad00be5f53a9a71e1b4895f54a71aaa21154bcce",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+  }

--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -3,8 +3,8 @@
     "short_description": "Roam Research plugin to hide/show the individual buttons in the left sidebar",
     "author": "Matt Vogel",
     "tags": ["left sidebar"],
-    "source_url": "https://github.com/8bitgentleman/hide-left-sidebar-buttons",
-    "source_repo": "https://github.com/8bitgentleman/hide-left-sidebar-buttons.git",
+    "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
+    "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
     "source_commit": "ad00be5f53a9a71e1b4895f54a71aaa21154bcce",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "ad00be5f53a9a71e1b4895f54a71aaa21154bcce",
+    "source_commit": "b14e461da17b8d61adfec300e37ee016265e5963",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
Plugin to hide/show the individual buttons in the left sidebar based on a request in the slack channel. Since new plugins have been adding buttons to the sidebar (and more are likely to come) I decided to go the JS route instead of just using CSS `nth-child()`

  <img src="https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons/raw/main/example.gif" max-width="400"></img>