### PR TITLE
improved stale sync, dedups on annotation text

### DIFF
--- a/extensions/getmatterapp/matter.json
+++ b/extensions/getmatterapp/matter.json
@@ -4,5 +4,5 @@
   "author": "The Matter Team",
   "source_url": "https://github.com/getmatterapp/roam-matter",
   "source_repo": "https://github.com/getmatterapp/roam-matter.git",
-  "source_commit": "1f302cdf0250703f621d83d929f123a33773eab3"
+  "source_commit": "40eb1027dcf57691c6d5a5d0faf60fc7ea7667e8"
 }


### PR DESCRIPTION
These changes do a couple of things:

For syncing:
1. Decreases the window of time for judging a sync stale, this should reduce the feeling that it's stuck.
2. Added some documentation that indicates it can seem stuck
3. Fixes a bug where stuck syncs wouldn't be restarted under manual sync intervals

For content:
1. De-duplicates the content of article pages by annotation text. This does mean there can be instances where the number of highlights does not match that in Matter (because they would contain the same text). But I figure that doesn't add any new information to the knowledge graph and saves us big headaches for users that uninstall/reinstall the application.