### PR TITLE
Small dedup bugfix - escape quote characters

### DIFF
--- a/extensions/getmatterapp/matter.json
+++ b/extensions/getmatterapp/matter.json
@@ -4,5 +4,5 @@
   "author": "The Matter Team",
   "source_url": "https://github.com/getmatterapp/roam-matter",
   "source_repo": "https://github.com/getmatterapp/roam-matter.git",
-  "source_commit": "40eb1027dcf57691c6d5a5d0faf60fc7ea7667e8"
+  "source_commit": "803bab5ccc94b96eaeca2b0ff0e6580720da69b5"
 }

--- a/extensions/getmatterapp/matter.json
+++ b/extensions/getmatterapp/matter.json
@@ -4,5 +4,5 @@
   "author": "The Matter Team",
   "source_url": "https://github.com/getmatterapp/roam-matter",
   "source_repo": "https://github.com/getmatterapp/roam-matter.git",
-  "source_commit": "803bab5ccc94b96eaeca2b0ff0e6580720da69b5"
+  "source_commit": "7e8fbfff257c1b70e29c417e9053fbb84142a434"
 }


### PR DESCRIPTION
Escapes quote characters to properly match text within page.