### PR TITLE
Left Sidebar Buttons: fix illegal char in settings id

### DIFF
--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -1,0 +1,10 @@
+{
+    "name": "Hide/Show Left Sidebar Buttons",
+    "short_description": "Roam Research plugin to hide/show the individual buttons in the left sidebar",
+    "author": "Matt Vogel",
+    "tags": ["left sidebar"],
+    "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
+    "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
+    "source_commit": "ad77ab3598eff928e0c030eb468d1dc1fed44ce2",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+  }


### PR DESCRIPTION
as detailed in #46 setting ids be non-empty strings and can't contain ".", "#", "$", "[", or "]"

