### PR TITLE
FIX Left Sidebar Button CSS Selectors

### DIFF
--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "ad77ab3598eff928e0c030eb468d1dc1fed44ce2",
+    "source_commit": "a5566c4dd096cf95681d6010d85c48deb03ca8aa",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
Y'all were tricky and changed the CSS & HTML structure on me. With Roam's new CSS before this fix the entire left sidebar would disappear. This should fix it