### PR TITLE
ptn roam-depot v0.0.4

### DIFF
--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "d1f04e91528f4804d4dbcb82df2f90711d560e12",
+  "source_commit": "e3acc15a9a363fe51742e9bd148db5389c3e1b2e",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "e3acc15a9a363fe51742e9bd148db5389c3e1b2e",
+  "source_commit": "344f836fc7476cbfaa747440991b4e24a622a061",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }


### PR DESCRIPTION
The main thing this adds is a quick alert to choose if we should make a new ptn key or not:
![image](https://user-images.githubusercontent.com/1139703/182740299-1a218265-9ccf-4882-a031-c2f548b82e9f.png)

i used blueprint to keep the dependencies minimal, pretty happy with how it all turned out. this should also fix the small issue where the settings page would open before the ptn key was set, making it less obvious what is going on. i hadn't noticed that because settings load immediately when installing from prod roam depot, not a local extension.

I think I'm now happy with the initial plugin and can get back to building fun new stuff

UPDATE 8/4 - v0.0.4 also fixes the settings, which are currently not always updating correctly.