### PR TITLE
Name Change: Table Import 

### DIFF
--- a/extensions/8bitgentleman/html-table-import.json
+++ b/extensions/8bitgentleman/html-table-import.json
@@ -1,10 +1,10 @@
 {
-    "name": "HTML Table Import",
-    "short_description": "Right-Click menu plugin: Converts an HTML table copied to the clipboard into a Roam Table format.",
+    "name": "Table Import",
+    "short_description": "Right-Click menu plugin: Converts an Excel or HTML table copied to the clipboard into a Roam Table format.",
     "author": "Matt Vogel",
     "tags": ["right-click menu", "import"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-html-table",
     "source_repo": "https://github.com/8bitgentleman/roam-depo-html-table.git",
-    "source_commit": "6db1db13361a011b7f913ffdc22cde117c6b0888",
+    "source_commit": "d493e53cee53f80e04cd37c7204dea129ebf08cf",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
This pull changes the name of the HTML Table Import plugin to the more general "Table Import" since it was recently pointed out to me that the plugin works with copied Excel tables as well. Test CSV attached
[test.csv](https://github.com/Roam-Research/roam-depot/files/9285442/test.csv)
 