### PR TITLE
update source_commit to ptn v0.0.6

### DIFF
--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "344f836fc7476cbfaa747440991b4e24a622a061",
+  "source_commit": "dc21341983cea2d618099bf69aaf691ff8c8b064",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }


### PR DESCRIPTION
v0.0.5 overhauls how attached images and documents from telegram work. when phonetonote receives a message with an attached file from telegram, i host it on a cloudflare bucket. when syncing the messages in roam, i now use `window.roamAlphaAPI.util.uploadFile` to store the image/file with the rest of the user's roam files. i can then delete the cloudflare image after syncing, which I do.