### PR TITLE
ptn v0.0.7

### DIFF
--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "acc1bc932e88876da660c62d9780d0cda3a6f54e",
+  "source_commit": "dc3d6a0d6bae92baebde096b0d7fc4c6f1e451a1",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "dc3d6a0d6bae92baebde096b0d7fc4c6f1e451a1",
+  "source_commit": "fe6e035d120c23d2e3b87339c4c41f09b7626853",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "344f836fc7476cbfaa747440991b4e24a622a061",
+  "source_commit": "acc1bc932e88876da660c62d9780d0cda3a6f54e",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }


### PR DESCRIPTION
v0.0.5 overhauls how attached images and documents from telegram work. when phonetonote receives a message with an attached file from telegram, i host it on a cloudflare bucket. when syncing the messages in roam, i now use `window.roamAlphaAPI.util.uploadFile` to store the image/file with the rest of the user's roam files. i can then delete the cloudflare image after syncing, which I do.

v0.0.6 better handles the edge case of unsuccessfully fetching a ptn key as you update your settings

v0.0.7 adds attachmentUrls to smartblocks