### PR TITLE
Matter: Adds article level note to article page

### DIFF
--- a/extensions/getmatterapp/matter.json
+++ b/extensions/getmatterapp/matter.json
@@ -4,5 +4,5 @@
   "author": "The Matter Team",
   "source_url": "https://github.com/getmatterapp/roam-matter",
   "source_repo": "https://github.com/getmatterapp/roam-matter.git",
-  "source_commit": "855fe5cf3bd502fc021d29d85ace2c9bd602673d"
+  "source_commit": "bf88b71c137efd067159811a2f69c8a56d1790b9"
 }


### PR DESCRIPTION
We've recently launched a new feature where a user can add a note at the top level of an article. This is useful for setting the context of the save, general takeaways, etc. This adds note to the article page inside of Roam.