### PR TITLE
remove stripe account from show-favicon extension (see pr #48 for details)

### DIFF
--- a/extensions/paulovieira/show-favicon.json
+++ b/extensions/paulovieira/show-favicon.json
@@ -5,6 +5,5 @@
     "tags": ["favicon", "icon", "links"],
     "source_url": "https://github.com/paulovieira/roam-show-favicon",
     "source_repo": "https://github.com/paulovieira/roam-show-favicon.git",
-    "source_commit": "466a51c62298ff7556b009bc8214cb486a016414",
-    "stripe_account": "acct_1LN3MzBk8GcWcVmg"
+    "source_commit": "466a51c62298ff7556b009bc8214cb486a016414"
 }


### PR DESCRIPTION
Just remove the stripe account to simplify distributing funds.

More details here: https://github.com/Roam-Research/roam-depot/pull/48