### PR TITLE
Export Tables

### DIFF
--- a/extensions/8bitgentleman/export-table.json
+++ b/extensions/8bitgentleman/export-table.json
@@ -5,6 +5,6 @@
     "tags": ["export", "button"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-table-export",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-table-export.git",
-    "source_commit": "6f72f185ae069610c9dbe005010f55727645737f",
+    "source_commit": "07b3c572a6a09e02ba04c202a5ee04b5dad0fb7d",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/export-table.json
+++ b/extensions/8bitgentleman/export-table.json
@@ -1,0 +1,10 @@
+{
+    "name": "Table Export",
+    "short_description": "Export a Roam table or Attribute table to CSV",
+    "author": "Matt Vogel",
+    "tags": ["export", "button"],
+    "source_url": "https://github.com/8bitgentleman/roam-depot-table-export",
+    "source_repo": "https://github.com/8bitgentleman/roam-depot-table-export.git",
+    "source_commit": "6f72f185ae069610c9dbe005010f55727645737f",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+  }

--- a/extensions/8bitgentleman/export-table.json
+++ b/extensions/8bitgentleman/export-table.json
@@ -5,6 +5,6 @@
     "tags": ["export", "button"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-table-export",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-table-export.git",
-    "source_commit": "07b3c572a6a09e02ba04c202a5ee04b5dad0fb7d",
+    "source_commit": "0069c03d507a1c76c32e6dccbee7d54a80a52231",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/html-table-import.json
+++ b/extensions/8bitgentleman/html-table-import.json
@@ -5,6 +5,6 @@
     "tags": ["right-click menu", "import"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-html-table",
     "source_repo": "https://github.com/8bitgentleman/roam-depo-html-table.git",
-    "source_commit": "d493e53cee53f80e04cd37c7204dea129ebf08cf",
+    "source_commit": "07b3c572a6a09e02ba04c202a5ee04b5dad0fb7d",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/html-table-import.json
+++ b/extensions/8bitgentleman/html-table-import.json
@@ -5,6 +5,6 @@
     "tags": ["right-click menu", "import"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-html-table",
     "source_repo": "https://github.com/8bitgentleman/roam-depo-html-table.git",
-    "source_commit": "07b3c572a6a09e02ba04c202a5ee04b5dad0fb7d",
+    "source_commit": "d493e53cee53f80e04cd37c7204dea129ebf08cf",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
Adds a button to export a table to CSV. 

Right now the button lives in the first cell of the table. 
<img width="764" alt="Screen Shot 2022-08-19 at 5 50 11 PM" src="https://user-images.githubusercontent.com/4028391/185711962-6110234d-3575-4b30-afdc-8d7a9ead7735.png">
I'd prefer if it could live next to the hover edit button on the far right but every time I added it to the `hoverparent` with `.hoveronly` clicking on the download button would just edit the block text. 
<img width="171" alt="image" src="https://user-images.githubusercontent.com/4028391/185712068-3ebf13e5-4ee7-4538-acf3-926506269384.png">

If there's a way to do this so editing the block isn't triggered on button click please let me know!



