### PR TITLE
Update show-favicon with the correct stripe account

### DIFF
--- a/extensions/paulovieira/show-favicon.json
+++ b/extensions/paulovieira/show-favicon.json
@@ -5,5 +5,6 @@
     "tags": ["favicon", "icon", "links"],
     "source_url": "https://github.com/paulovieira/roam-show-favicon",
     "source_repo": "https://github.com/paulovieira/roam-show-favicon.git",
-    "source_commit": "466a51c62298ff7556b009bc8214cb486a016414"
+    "source_commit": "466a51c62298ff7556b009bc8214cb486a016414",
+    "stripe_account": "acct_1LaeDFQkjlKJqKKW"
 }


### PR DESCRIPTION
It seems I messed up something before when trying to create the express stripe account. I probably didn't choose the country correctly.

Anyway, I managed to created / finish the stripe account using a bank account in Portugal, with no problems.

More details here: https://github.com/Roam-Research/roam-depot/pull/48#issuecomment-1214469738