### PR TITLE
ptn v0.0.8

### DIFF
--- a/extensions/phonetonote/phonetonote.json
+++ b/extensions/phonetonote/phonetonote.json
@@ -5,6 +5,6 @@
   "tags": ["phonetonote", "ptn"],
   "source_url": "https://github.com/phonetonote/ptn-roam-depot",
   "source_repo": "https://github.com/phonetonote/ptn-roam-depot.git",
-  "source_commit": "fe6e035d120c23d2e3b87339c4c41f09b7626853",
+  "source_commit": "b896e3f2b4a3eb3d9dd3c6c231b6b5e3b64d178f",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }


### PR DESCRIPTION
Version v0.0.8 removes the default ptn hashtag to resolve https://github.com/phonetonote/ptn-roam-depot/issues/4 and cleans up some other settings wording