### PR TITLE
Clear Sidebar: Alert

### DIFF
--- a/extensions/8bitgentleman/clear-sidebar.json
+++ b/extensions/8bitgentleman/clear-sidebar.json
@@ -5,7 +5,7 @@
     "tags": ["right sidebar", "button"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-clear-sidebar",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-clear-sidebar.git",
-    "source_commit": "0d50982067f182d087965482dfcb2dc24ac62682",
+    "source_commit": "9827bfa68982abdd62c598aa6c6c37b741687507",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Adds the option to display an alert when clearing the sidebar, as requested on slack. This option is disabled by default.

To do this I converted the extension to use roamjs-components which has the downside of greatly increasing the final size of the compiled extension