### PR TITLE
code block copy: inline copy as optional

### DIFF
--- a/extensions/8bitgentleman/code-block-copy.json
+++ b/extensions/8bitgentleman/code-block-copy.json
@@ -1,10 +1,10 @@
 {
     "name": "Code Block Copy Button",
-    "short_description": "Adds a button to copy the contents of a code clock to the clipboard",
+    "short_description": "Adds a button to copy the contents of a code block to the clipboard",
     "author": "Matt Vogel",
     "tags": ["code-block"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-copy-code-block",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-copy-code-block.git",
-    "source_commit": "c36a2181ce96f8e7c77eb2fa9d13f3d2090cdf4b",
+    "source_commit": "19599f52e23de5c2b8018722007ad4b872f8024e",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 }


### PR DESCRIPTION
Make the inline copy button optional (on as default) as some users don't use that purely for code and found it annoying