### PR TITLE
reference path

### DIFF
--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -1,0 +1,9 @@
+{
+	"name": "Reference path",
+	"short_description": "Display the reference path for the block being edited",
+	"author": "Paulo Vieira",
+	"tags": ["reference path"],
+	"source_url": "https://github.com/paulovieira/roam-reference-path",
+	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
+	"source_commit": "f6a4a854ab3e3345c6684ebf7d009a6a63f7650e"
+}


### PR DESCRIPTION
This is finally ready for review.

There is no stripe acount in the json. This is on purpose as the original work on this plugin was done by @azlen (Azlen Elza). I have contacted him by email about submitting the plugin and he said it was ok. I will contact him later to eventually split any possible payments.

More background here: https://github.com/Roam-Research/roam-depot/pull/48
