### PR TITLE
FIX Update toggle-uppercase.json

### DIFF
--- a/extensions/8bitgentleman/toggle-uppercase.json
+++ b/extensions/8bitgentleman/toggle-uppercase.json
@@ -1,5 +1,5 @@
 {
-    "name": "Table Import",
+    "name": "Toggle Text Uppercase/Lowercase",
     "short_description": "Right-Click menu plugin: Toggles all block text to Uppercase or lowercase",
     "author": "Matt Vogel",
     "tags": ["right-click menu", "formatting"],


### PR DESCRIPTION
@panterarocks49  looks like the name in the origional JSON was never changed and it has overwritten my "Table Import" extension in the store. My Table Import plugin, which had previously been doing quite well, is now showing as 0 and points to an incorrect extension. This is 100% my bad, apologies, hope the Table Import downloads can be restored 😨
<img width="303" alt="image" src="https://user-images.githubusercontent.com/4028391/188035984-50dc5ef7-a211-4ac4-9f4a-574c20ec3da1.png">
