### PR TITLE
Update scrollbars.json

### DIFF
--- a/extensions/paulovieira/scrollbars.json
+++ b/extensions/paulovieira/scrollbars.json
@@ -5,6 +5,6 @@
 	"tags": ["scrollbars", "block embed", "page embed", "code block"],
 	"source_url": "https://github.com/paulovieira/roam-scrollbars",
 	"source_repo": "https://github.com/paulovieira/roam-scrollbars.git",
-	"source_commit": "266769f4656de9f7218f6d03d1a88d70a0e867bf",
+	"source_commit": "38b97577cb96e873997a9ed0ac47751bb83cdd45",
 	"stripe_account": "acct_1LaeDFQkjlKJqKKW"
 }


### PR DESCRIPTION
This update addresses a few places in roam where showing the scrollbar is also useful. More details here: paulovieira/roam-scrollbars#3

Meanwhile I found a related bug: in the settings panel, the main tab is not scrollable. See the screenshot here:

https://user-images.githubusercontent.com/2184309/188222688-68df7618-8a9a-48be-aa89-e20c24fbd1be.png

If the viewport is small I cannot reach the tabs for the extensions settings.

EDIT: this bug is not present in the android mobile app.