### PR TITLE
Fixes - Focus Mode

### DIFF
--- a/extensions/mlava/focus-mode.json
+++ b/extensions/mlava/focus-mode.json
@@ -5,6 +5,6 @@
   "tags": ["focus"],
   "source_url": "https://github.com/mlava/focus-mode",
   "source_repo": "https://github.com/mlava/focus-mode.git",
-  "source_commit": "4ce3b3e2f71a2188a9890721a17c8d66dd59b743",
+  "source_commit": "dfbc5b1b4b5acbc1e0605d0f5ed8eac16fea6862",
   "stripe_account": "acct_1LNVRQQVHUZMIiOR"
 }


### PR DESCRIPTION
Allow dynamic update when changing Roam Depot settings - the user can turn on Focus Mode and then change the settings to see their effect.