### PR TITLE
Workbench: Version 2022-09-03-17-44

### DIFF
--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "998336a992baff828a8bcf8d225d2a5105afcc52",
+    "source_commit": "dd86a56db0b2af2f3c81a85b2ae72ebf42487ef5",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "0e18d7b947e04ed0618c6964e5eb5d56474f426f",
+    "source_commit": "0a68543ff10c909187e7c40bf68ea2a42b6fc2a0",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "359ef6297d0f680cdbd22fd4b2b2b67dda96fb96",
+    "source_commit": "0e18d7b947e04ed0618c6964e5eb5d56474f426f",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "dd86a56db0b2af2f3c81a85b2ae72ebf42487ef5",
+    "source_commit": "bece7304512af781adbd3dc088ec696b0d59cb4a",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "0a68543ff10c909187e7c40bf68ea2a42b6fc2a0",
+    "source_commit": "998336a992baff828a8bcf8d225d2a5105afcc52",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "8e1078e9a21159aa54174d9dff970f5044faf42a",
+    "source_commit": "359ef6297d0f680cdbd22fd4b2b2b67dda96fb96",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "2352522157f00d0f81b6ab6aff36b4e25f028be1",
+    "source_commit": "8e1078e9a21159aa54174d9dff970f5044faf42a",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "bece7304512af781adbd3dc088ec696b0d59cb4a",
+    "source_commit": "4897093a76811e17630f2359532959826ff748ac",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -1,0 +1,10 @@
+{
+    "name": "Workbench",
+    "short_description": "A delightfully fun collection of power user tools for Roam.",
+    "author": "David Vargas",
+    "tags": [],
+    "source_url": "https://github.com/dvargas92495/roamjs-workbench",
+    "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
+    "source_commit": "2352522157f00d0f81b6ab6aff36b4e25f028be1",
+    "stripe_account": "acct_1LGDNwQhxYPoO7v8"
+}

--- a/extensions/dvargas92495/workbench.json
+++ b/extensions/dvargas92495/workbench.json
@@ -5,6 +5,6 @@
     "tags": [],
     "source_url": "https://github.com/dvargas92495/roamjs-workbench",
     "source_repo": "https://github.com/dvargas92495/roamjs-workbench.git",
-    "source_commit": "4897093a76811e17630f2359532959826ff748ac",
+    "source_commit": "3fb56cd39ae456db1c98cebade66cece2509c79e",
     "stripe_account": "acct_1LGDNwQhxYPoO7v8"
 }


### PR DESCRIPTION
Well It's finally here.

I decided to completely rewrite Roam42 and publish it as WorkBench to Roam Depot. All old files are in the `/legacy` file and are not used in the actual submission. They're there to give an idea of what the original code looked like, and to patch any emergencies that come up during the migration. This folder will be removed once WorkBench is live on RoamDepot for a few weeks.

There are probably several questionable instances of logic here - don't be afraid to be critical. I imagine that there are still things I need to clean up before it actually reaches the store.