### PR TITLE
Update reference-path.json

### DIFF
--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,5 +5,5 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "afc90c1ca454282de9ce12d5c0a6b2ec4b2f798f"
+	"source_commit": "e66f6c5ce52d2cd1e566bbd336ac939b5531aa03"
 }

--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,5 +5,5 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "e66f6c5ce52d2cd1e566bbd336ac939b5531aa03"
+	"source_commit": "a994d045d0e019cf2f79f26b026a10d96393702f"
 }

--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,5 +5,5 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "a994d045d0e019cf2f79f26b026a10d96393702f"
+	"source_commit": "80191d0ebd41d63405ed2ea79073e026087a5a6d"
 }


### PR DESCRIPTION
Added a minimal commit to add a few more option in the offset settings. The rest is the same.

This is necessary to make this extension compatible with the Roam Studio extension, which changes the default css so much that the reference path is way off the center of the bullet. However it's just a mater of doing a correction with the "top offset" setting.