### PR TITLE
Bug Fixes for Quick Capture

### DIFF
--- a/extensions/mlava/quick-capture.json
+++ b/extensions/mlava/quick-capture.json
@@ -5,6 +5,6 @@
   "tags": ["todoist", "capture", "import"],
   "source_url": "https://github.com/mlava/quick-capture",
   "source_repo": "https://github.com/mlava/quick-capture.git",
-  "source_commit": "4f2a0048b47dfc26b0e4c6dc5c1f822aa1ed37d6",
+  "source_commit": "7222d95e063c5d8287c1e52f05170f4111d89d2b",
   "stripe_account": "acct_1LNVRQQVHUZMIiOR"
 }


### PR DESCRIPTION
Restore delete on import
Create option for labelling in Todoist on import rather than deleting - https://github.com/Roam-Research/roam-depot/pull/200#issuecomment-1249965312 Allow import of Todoist labels and convert to RR tags