### PR TITLE
Update reference-path.json

### DIFF
--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,6 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "c2236131b6319aea2a1d1d3c670e61b77b532442",
+	"source_commit": "f3c31286aea1370946dae456146f6a1fb8c13421",
 	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }

--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,6 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "f3c31286aea1370946dae456146f6a1fb8c13421",
+	"source_commit": "79db920dd762f386aefcece891f71fcb0c38a530",
 	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }

--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,6 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "79db920dd762f386aefcece891f71fcb0c38a530",
+	"source_commit": "5b0dccf4182184567bea8b08f92ecef7ad45a05f",
 	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }

--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,6 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "5b0dccf4182184567bea8b08f92ecef7ad45a05f",
+	"source_commit": "4d7ec2b891cc0e5e788b5ceaf95e7cc54e047704",
 	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }

--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,6 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "80191d0ebd41d63405ed2ea79073e026087a5a6d",
+	"source_commit": "c2236131b6319aea2a1d1d3c670e61b77b532442",
 	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }

--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,5 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "80191d0ebd41d63405ed2ea79073e026087a5a6d"
+	"source_commit": "80191d0ebd41d63405ed2ea79073e026087a5a6d",
+	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }


### PR DESCRIPTION
- Add the stripe account for this extension (which was missing on purpose until now). 
- Add hover mode (https://github.com/paulovieira/roam-reference-path/issues/12)

Some notes about the stripe account:
- I've contacted the original author of the extension (@azlen) about this subject and offered to split the payout.
- The stripe account being added here is different from the one used in my other extensions. This one was created using the roam account of a relative of mine and will be used exclusively for this extension. This way it's possible to separate the payouts from this extension and from the other ones, which will facilitate the split.

More stuff:
- new feature: hover mode (paulovieira/roam-reference-path#12)
- fix for a supposed incompatibility with smart blocks (paulovieira/roam-reference-path#14)
- proper handling of the lifecycle of mouse hover event listeners (paulovieira/roam-reference-path#15)
- improve hover modo color (paulovieira/roam-reference-path#16)