### PR TITLE
New Extension: Image Generator

### DIFF
--- a/extensions/phonetonote/image-generator.json
+++ b/extensions/phonetonote/image-generator.json
@@ -1,0 +1,10 @@
+{
+  "name": "image generator",
+  "short_description": "generate Stable Diffusion images from any block of text",
+  "author": "scott block",
+  "tags": ["image generation", "image generator", "text to image", "stable diffusion"],
+  "source_url": "https://github.com/phonetonote/image-generator",
+  "source_repo": "https://github.com/phonetonote/image-generator.git",
+  "source_commit": "3cf7c3a812cea6825b78b0b9be0a8e99b1c17092",
+  "stripe_account": "acct_1LKwanQVF0QOKIg5"
+}

--- a/extensions/phonetonote/image-generator.json
+++ b/extensions/phonetonote/image-generator.json
@@ -1,10 +1,10 @@
 {
-  "name": "image generator",
+  "name": "Image Generator",
   "short_description": "generate Stable Diffusion images from any block of text",
   "author": "scott block",
   "tags": ["image generation", "image generator", "text to image", "stable diffusion"],
   "source_url": "https://github.com/phonetonote/image-generator",
   "source_repo": "https://github.com/phonetonote/image-generator.git",
-  "source_commit": "3cf7c3a812cea6825b78b0b9be0a8e99b1c17092",
+  "source_commit": "76bc405ee87f2d9ddd9bd23bbea73ab4c72fc8b9",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }


### PR DESCRIPTION
`image generator` is a new plugin to generate Stable Diffusion images from right inside Roam. It works via the command palette and block context menu. [quick demo here](https://user-images.githubusercontent.com/1139703/191873385-db352955-f334-4cfe-930a-329157d768f4.mp4).