### PR TITLE
Roam Memo: Release v8: Fix Create API Regression

### DIFF
--- a/extensions/digitalmaster/roam-memo.json
+++ b/extensions/digitalmaster/roam-memo.json
@@ -5,6 +5,6 @@
     "tags": ["spaced repetition"],
     "source_url": "https://github.com/digitalmaster/roam-memo",
     "source_repo": "https://github.com/digitalmaster/roam-memo.git",
-    "source_commit": "fe072b66440f1adb76b6e9621f335e6672fdebc0",
+    "source_commit": "5c6b22fdf8f43189d25ad5dea43968d5760bed6d",
     "stripe_account": "acct_1LZNprQe7Pm7RMMV"
   }


### PR DESCRIPTION
Just noticed that the page creation API now throws an error if you try to create a page that already exists: 
<img width="1287" alt="CleanShot 2022-09-30 at 21 27 11@2x" src="https://user-images.githubusercontent.com/1279335/193377806-758b3aae-62bb-4672-84fe-94e49f03f514.png">

It also throws an error if you don't pass it a UID: 
<img width="884" alt="CleanShot 2022-09-30 at 21 29 32@2x" src="https://user-images.githubusercontent.com/1279335/193377846-6ec78e91-0192-454f-b520-61938fdc4599.png">


This plugin (and i'm sure many others are broken as a result) 😬