### PR TITLE
Bugfix: Completely removed calendar icon in front of date links for the moment

### DIFF
--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "812122d5fffcc7205cf8f9d1a231bdbc7baa34f9",
+  "source_commit": "761d30e205c7f49564612faa95a6eec3716f8075",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "53a733dc6984f532c8bac4a695f712306530e3bd",
+  "source_commit": "c7c93cc461eb88b55ca20ce679826237e6f93970",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "2b43fc19d631ed6197abebedf1545ddaa37cfc62",
+  "source_commit": "c6f14cf443cc6eaf570ad2f41f719ac145d2c9d9",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "c6f14cf443cc6eaf570ad2f41f719ac145d2c9d9",
+  "source_commit": "66a3b4ab5b76011268c8c26c209527e493834d30",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "81ca3433521b8f9f94623030070616bc7cc7a6fa",
+  "source_commit": "4c7c708e63e953cec3434d406130d6970103051b",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roam Studio",
+  "short_description": "Beautiful and easily customizable themes for Roam Research.",
+  "author": "Alexander Rink",
+  "source_url": "https://github.com/rcvd/RoamStudio",
+  "source_repo": "https://github.com/rcvd/RoamStudio.git",
+  "source_commit": "81ca3433521b8f9f94623030070616bc7cc7a6fa",
+  "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
+}

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "66a3b4ab5b76011268c8c26c209527e493834d30",
+  "source_commit": "53a733dc6984f532c8bac4a695f712306530e3bd",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "c7c93cc461eb88b55ca20ce679826237e6f93970",
+  "source_commit": "812122d5fffcc7205cf8f9d1a231bdbc7baa34f9",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "c6a4d7d639ffb962fef7ff5d75869bc5787c61ff",
+  "source_commit": "2b43fc19d631ed6197abebedf1545ddaa37cfc62",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "918ea77db4148551b0f53c36a6023eef64d4d668",
+  "source_commit": "c6a4d7d639ffb962fef7ff5d75869bc5787c61ff",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }

--- a/extensions/rcvd/RoamStudio.json
+++ b/extensions/rcvd/RoamStudio.json
@@ -4,6 +4,6 @@
   "author": "Alexander Rink",
   "source_url": "https://github.com/rcvd/RoamStudio",
   "source_repo": "https://github.com/rcvd/RoamStudio.git",
-  "source_commit": "4c7c708e63e953cec3434d406130d6970103051b",
+  "source_commit": "918ea77db4148551b0f53c36a6023eef64d4d668",
   "stripe_account": "acct_1LPgSxQUtJ9VpaGT"
 }


### PR DESCRIPTION
I can't get Unicode CSS content to work within the plugin (e.g. content: "\e62b";), the backslash will always be removed resulting in a number instead of an icon (see slack question). Temporarily removed it completely until I found a real fix.