### PR TITLE
Update reference-path.json

### DIFF
--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,6 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "4d7ec2b891cc0e5e788b5ceaf95e7cc54e047704",
+	"source_commit": "3c91047462fe5092de78face3ae33caee94a1df9",
 	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }


### PR DESCRIPTION
The reference-path plugin had a conflict with Workbench/DeepNav. 

More details here: https://github.com/paulovieira/roam-reference-path/issues/17