### PR TITLE
Update roam-preview-panels

### DIFF
--- a/extensions/hyc/roam-preview-panels.json
+++ b/extensions/hyc/roam-preview-panels.json
@@ -4,6 +4,6 @@
   "author": "hyc",
   "source_url": "https://github.com/dive2Pro/roam-preview-panels",
   "source_repo": "https://github.com/dive2Pro/roam-preview-panels.git",
-  "source_commit": "88132ddad35642d1d32416ce8dd468c3a23ca53e",
+  "source_commit": "16dd6a3c5181ae69d14170b0cf66cd8e51762375",
   "stripe_account": "acct_1LLkJkQbYbNOfzpa"
 }

--- a/extensions/hyc/roam-preview-panels.json
+++ b/extensions/hyc/roam-preview-panels.json
@@ -4,6 +4,6 @@
   "author": "hyc",
   "source_url": "https://github.com/dive2Pro/roam-preview-panels",
   "source_repo": "https://github.com/dive2Pro/roam-preview-panels.git",
-  "source_commit": "fdc4c84338648ac52c2dd474bdb1f458708a5faa",
+  "source_commit": "06454f11fa532da65fb9c9b14efc5422d9abc2b9",
   "stripe_account": "acct_1LLkJkQbYbNOfzpa"
 }

--- a/extensions/hyc/roam-preview-panels.json
+++ b/extensions/hyc/roam-preview-panels.json
@@ -4,6 +4,6 @@
   "author": "hyc",
   "source_url": "https://github.com/dive2Pro/roam-preview-panels",
   "source_repo": "https://github.com/dive2Pro/roam-preview-panels.git",
-  "source_commit": "a27c7674986f095c529ccc96dac79ff0291f07a8",
+  "source_commit": "88132ddad35642d1d32416ce8dd468c3a23ca53e",
   "stripe_account": "acct_1LLkJkQbYbNOfzpa"
 }

--- a/extensions/hyc/roam-preview-panels.json
+++ b/extensions/hyc/roam-preview-panels.json
@@ -4,6 +4,6 @@
   "author": "hyc",
   "source_url": "https://github.com/dive2Pro/roam-preview-panels",
   "source_repo": "https://github.com/dive2Pro/roam-preview-panels.git",
-  "source_commit": "06454f11fa532da65fb9c9b14efc5422d9abc2b9",
+  "source_commit": "a27c7674986f095c529ccc96dac79ff0291f07a8",
   "stripe_account": "acct_1LLkJkQbYbNOfzpa"
 }

--- a/extensions/hyc/roam-preview-panels.json
+++ b/extensions/hyc/roam-preview-panels.json
@@ -4,6 +4,6 @@
   "author": "hyc",
   "source_url": "https://github.com/dive2Pro/roam-preview-panels",
   "source_repo": "https://github.com/dive2Pro/roam-preview-panels.git",
-  "source_commit": "16dd6a3c5181ae69d14170b0cf66cd8e51762375",
+  "source_commit": "2d7440b00303810c8dd0eceede7e1bf22e6835c5",
   "stripe_account": "acct_1LLkJkQbYbNOfzpa"
 }

--- a/extensions/hyc/roam-preview-panels.json
+++ b/extensions/hyc/roam-preview-panels.json
@@ -4,6 +4,6 @@
   "author": "hyc",
   "source_url": "https://github.com/dive2Pro/roam-preview-panels",
   "source_repo": "https://github.com/dive2Pro/roam-preview-panels.git",
-  "source_commit": "2d7440b00303810c8dd0eceede7e1bf22e6835c5",
+  "source_commit": "d4df5bcd9b67291605ef73ed09b450b08c8d6b93",
   "stripe_account": "acct_1LLkJkQbYbNOfzpa"
 }


### PR DESCRIPTION
- You can set the default size of the panel
- You can specify a modifier key so that the panel only appears when you press and hold the modifier key.
- The state of the panel is automatically saved, and restored after you refresh the page or change browsers, 
- The theme of the panel is now fitted to the  [Roam-Studio](https://github.com/rcvd/RoamStudio)
