### PR TITLE
New Extension - Similar Pages

### DIFF
--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -1,0 +1,10 @@
+{
+  "name": "Similar Pages",
+  "short_description": "uses machine learning and graph theory to help you find connections between ideas",
+  "author": "scott block",
+  "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
+  "source_url": "https://github.com/phonetonote/similar-pages",
+  "source_repo": "https://github.com/phonetonote/similar-pages",
+  "source_commit": "417480eb2bbe809d80ede5556dca035e633225a8",
+  "stripe_account": "acct_1LKwanQVF0QOKIg5"
+}

--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -5,6 +5,6 @@
   "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
   "source_url": "https://github.com/phonetonote/similar-pages",
   "source_repo": "https://github.com/phonetonote/similar-pages",
-  "source_commit": "417480eb2bbe809d80ede5556dca035e633225a8",
+  "source_commit": "61b8e870d130cf970d368ce603692f0a2e564572",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -5,6 +5,6 @@
   "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
   "source_url": "https://github.com/phonetonote/similar-pages",
   "source_repo": "https://github.com/phonetonote/similar-pages",
-  "source_commit": "61b8e870d130cf970d368ce603692f0a2e564572",
+  "source_commit": "3ff405740863f73621cc0c7bccaee5909d2e685e",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }


### PR DESCRIPTION
similar pages uses machine learning and graph theory to help you find connections between ideas.

demo and overview - https://www.loom.com/share/d034cbf2909442e5bea4a6bca2a962f9

you can also see more on the [README](https://github.com/phonetonote/similar-pages), including a little about how it works (webworkers and indexeddb only, nothing being sent to a server). happy to answer any questions. I was originally working on this way back before roam depot launched, so excited to finally ship this!
