### PR TITLE
zoteroRoam: update to v0.7.7

### DIFF
--- a/extensions/alixlahuec/zotero-roam.json
+++ b/extensions/alixlahuec/zotero-roam.json
@@ -5,6 +5,6 @@
 	"tags": ["zotero", "import", "academic"],
 	"source_url": "https://github.com/alixlahuec/zotero-roam",
 	"source_repo": "https://github.com/alixlahuec/zotero-roam.git",
-	"source_commit": "efbaaf18ca74ad9c1c0fc406d205dcba0ab5ec87",
+	"source_commit": "f91980f6292207d0d8d0dd61adb1b6bdcf85e363",
 	"stripe_account": "acct_1LRdeCQUvCSLsEj3"
 }

--- a/extensions/alixlahuec/zotero-roam.json
+++ b/extensions/alixlahuec/zotero-roam.json
@@ -5,6 +5,6 @@
 	"tags": ["zotero", "import", "academic"],
 	"source_url": "https://github.com/alixlahuec/zotero-roam",
 	"source_repo": "https://github.com/alixlahuec/zotero-roam.git",
-	"source_commit": "e6b07805cfa9d497c708ca3932c8f2faae372386",
+	"source_commit": "efbaaf18ca74ad9c1c0fc406d205dcba0ab5ec87",
 	"stripe_account": "acct_1LRdeCQUvCSLsEj3"
 }


### PR DESCRIPTION
## Changes

- fix: fatal crash due to invalid shortcuts ([#96](https://github.com/alixlahuec/zotero-roam/issues/96))
- fix: race condition with Smartblocks ([#97](https://github.com/alixlahuec/zotero-roam/issues/97))
- chore: fix shortcuts validation with empty string ([#100](https://github.com/alixlahuec/zotero-roam/pull/100))