### PR TITLE
Update zoteroRoam - v0.7.8

### DIFF
--- a/extensions/alixlahuec/zotero-roam.json
+++ b/extensions/alixlahuec/zotero-roam.json
@@ -5,6 +5,6 @@
 	"tags": ["zotero", "import", "academic"],
 	"source_url": "https://github.com/alixlahuec/zotero-roam",
 	"source_repo": "https://github.com/alixlahuec/zotero-roam.git",
-	"source_commit": "f91980f6292207d0d8d0dd61adb1b6bdcf85e363",
+	"source_commit": "36f751a8f98ec27915fe588a996c8054fee91043",
 	"stripe_account": "acct_1LRdeCQUvCSLsEj3"
 }


### PR DESCRIPTION
## Changes

* [fix: ZOTEROITEMCOLLECTIONS doesn't return output](https://github.com/alixlahuec/zotero-roam/pull/110)
* [feat: sort annotations and notes for import](https://github.com/alixlahuec/zotero-roam/pull/102)
* [feat: add custom nesting options for notes](https://github.com/alixlahuec/zotero-roam/pull/112)
* [feat: expand formatting options for autocomplete](https://github.com/alixlahuec/zotero-roam/pull/114)
* [feat: add interface to view logs](https://github.com/alixlahuec/zotero-roam/pull/115)

* [tests: add coverage for SmartBlocks commands](https://github.com/alixlahuec/zotero-roam/pull/111)
* [chore: fix path in README](https://github.com/alixlahuec/zotero-roam/pull/113)
* [chore(deps): update dependency webpack-cli to v5](https://github.com/alixlahuec/zotero-roam/pull/95)
* [chore(deps): update dependency mini-css-extract-plugin to ^2.7.0](https://github.com/alixlahuec/zotero-roam/pull/94)
* [chore(deps): update dependency @storybook/test-runner to ^0.9.1](https://github.com/alixlahuec/zotero-roam/pull/104)
* [chore(deps): update dependency @storybook/addon-coverage to ^0.0.7](https://github.com/alixlahuec/zotero-roam/pull/103)
* [chore(deps): update dependency babel-loader to v9](https://github.com/alixlahuec/zotero-roam/pull/106)
* [chore(deps): update dependency webpack to ^5.75.0](https://github.com/alixlahuec/zotero-roam/pull/105)
* [chore(deps): update dependency release-it to ^15.5.0](https://github.com/alixlahuec/zotero-roam/pull/109)