### PR TITLE
crucial fix for Reference Expands

### DIFF
--- a/extensions/hyc/roam-reference-expands.json
+++ b/extensions/hyc/roam-reference-expands.json
@@ -4,6 +4,6 @@
   "author": "hyc",
   "source_url": "https://github.com/dive2Pro/roam-reference-expand",
   "source_repo": "https://github.com/dive2Pro/roam-reference-expand.git",
-  "source_commit": "309b6705ac5bd0d17b9928b8044ce3d1dcfa18cf",
+  "source_commit": "e04b39686ff352a253a516e4eb5cfc2d1f4dd3ad",
   "stripe_account": "acct_1LLkJkQbYbNOfzpa"
 }


### PR DESCRIPTION
If the user check a todo block that has already been referenced, Roam will crash.