### PR TITLE
New Extension: Youtube Transcripts

### DIFF
--- a/extensions/phonetonote/youtube-transcripts.json
+++ b/extensions/phonetonote/youtube-transcripts.json
@@ -15,6 +15,6 @@
   ],
   "source_url": "https://github.com/phonetonote/youtube-transcripts",
   "source_repo": "https://github.com/phonetonote/youtube-transcripts.git",
-  "source_commit": "4197535ca5657502bd45fe5654a9e242b22359e4",
+  "source_commit": "a4e34663ddc05c6e39f0e0df8bf125aa205b23a0",
   "stripe_account": "acct_1LKwanQVF0QOKIg5"
 }

--- a/extensions/phonetonote/youtube-transcripts.json
+++ b/extensions/phonetonote/youtube-transcripts.json
@@ -1,0 +1,20 @@
+{
+  "name": "Youtube Transcripts",
+  "short_description": "get transcripts from youtube videos inside roam",
+  "author": "scott block",
+  "tags": [
+    "youtube",
+    "transcript",
+    "transcripts",
+    "subtitle",
+    "subtitles",
+    "caption",
+    "captions",
+    "closed caption",
+    "closed captions"
+  ],
+  "source_url": "https://github.com/phonetonote/youtube-transcripts",
+  "source_repo": "https://github.com/phonetonote/youtube-transcripts.git",
+  "source_commit": "4197535ca5657502bd45fe5654a9e242b22359e4",
+  "stripe_account": "acct_1LKwanQVF0QOKIg5"
+}


### PR DESCRIPTION
New extension to fetch youtube transcripts and put them into your graph. This uses https://youtubetranscript.com/, which gets them straight from youtube. This does not use whisper or anything fancy (for now).

Demo:

https://user-images.githubusercontent.com/1139703/211221319-cfcf2083-53e7-4163-b071-129923345437.mp4

See the README in the repo for full usage.