### PR TITLE
Update tweet-extractor.json

### DIFF
--- a/extensions/8bitgentleman/tweet-extractor.json
+++ b/extensions/8bitgentleman/tweet-extractor.json
@@ -5,7 +5,7 @@
     "tags": ["twitter"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-tweet-extract",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-tweet-extract.git",
-    "source_commit": "cfc74e7d2e5430e598030d4f4690535a81d79922",
+    "source_commit": "4c947c473b29e46b4ff668de389a0223479da78c",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Adds in the ability to extract images from a tweet and uploads them to your roam graph. As mentioned in the README I have used a simple CORS proxy to get tweet info. _Zero_ personal info is sent through the proxy, only the tweet ID.