### PR TITLE
Update dark-theme-toggle.json

### DIFF
--- a/extensions/8bitgentleman/dark-theme-toggle.json
+++ b/extensions/8bitgentleman/dark-theme-toggle.json
@@ -2,10 +2,10 @@
     "name": "CSS Dark Mode Toggle",
     "short_description": "Adds a button to the topbar to toggle a theme's dark mode manually. CSS NOT INCLUDED",
     "author": "Matt Vogel",
-    "tags": ["topbar", "button", "CSS"],
+    "tags": ["topbar", "button", "CSS", "theme", "dark theme"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-dark-toggle",
     "source_repo": "https://github.com/8bitgentleman/roam-depo-dark-toggle.git",
-    "source_commit": "1e09f12c85451aa3dbf4d3ed7437b7037154243a",
+    "source_commit": "6ab5204415807d95d5209c0b3b5a85ea4b178d52",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Adds optional CSS for a simple dark theme. I've opted to add/remove the css directly onto the `[[roam/css]]` page so that users can view and potentially modify the code. The main point of this extension is to allow users the freedom and flexibility to create their own themes and potentially learn from a simple example