### PR TITLE
FIX: Dark Theme Toggle

### DIFF
--- a/extensions/8bitgentleman/dark-theme-toggle.json
+++ b/extensions/8bitgentleman/dark-theme-toggle.json
@@ -1,6 +1,6 @@
 {
     "name": "CSS Dark Mode Toggle",
-    "short_description": "Adds a button to the topbar to toggle a theme's dark mode manually. CSS NOT INCLUDED",
+    "short_description": "Adds a button to the topbar to toggle a theme's dark mode manually. Simple dark theme now included!",
     "author": "Matt Vogel",
     "tags": ["topbar", "button", "CSS", "theme", "dark theme"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-dark-toggle",

--- a/extensions/8bitgentleman/dark-theme-toggle.json
+++ b/extensions/8bitgentleman/dark-theme-toggle.json
@@ -5,7 +5,7 @@
     "tags": ["topbar", "button", "CSS", "theme", "dark theme"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-dark-toggle",
     "source_repo": "https://github.com/8bitgentleman/roam-depo-dark-toggle.git",
-    "source_commit": "6ab5204415807d95d5209c0b3b5a85ea4b178d52",
+    "source_commit": "4f1866139e0890ce8926f0c841f91c311cd19164",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
fix an accidental override of a user's default theme when the CSS blocks were placed at the top of roam/css