### PR TITLE
Update Quick Capture - rename Todoist labels

### DIFF
--- a/extensions/mlava/quick-capture.json
+++ b/extensions/mlava/quick-capture.json
@@ -5,6 +5,6 @@
   "tags": ["todoist", "capture", "import"],
   "source_url": "https://github.com/mlava/quick-capture",
   "source_repo": "https://github.com/mlava/quick-capture.git",
-  "source_commit": "f49de2071e695f8fb1d55fedaac7c64ede5892f3",
+  "source_commit": "79014d3edde4c9ea39723ca79dc687a71fcb9785",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
replace underscore in Todoist label with space in Roam Research tag