### PR TITLE
update: roam website title parser

### DIFF
--- a/extensions/dragonforce2010/roam-website-title-parser.json
+++ b/extensions/dragonforce2010/roam-website-title-parser.json
@@ -7,6 +7,6 @@
   ],
   "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
   "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
-  "source_commit": "773e07c7fd3ee390c1cb515996c1102e7c4becc6",
+  "source_commit": "aacaf14df9805751d6b2a6535836a88e18253b68",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-website-title-parser.json
+++ b/extensions/dragonforce2010/roam-website-title-parser.json
@@ -7,6 +7,6 @@
   ],
   "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
   "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
-  "source_commit": "5c29ce625e3b20707ae420cc24b5b2c8dbba1a2a",
+  "source_commit": "bb8b416cc80210417abf026de62fdf9147ab9005",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-website-title-parser.json
+++ b/extensions/dragonforce2010/roam-website-title-parser.json
@@ -7,6 +7,6 @@
   ],
   "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
   "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
-  "source_commit": "bb8b416cc80210417abf026de62fdf9147ab9005",
+  "source_commit": "773e07c7fd3ee390c1cb515996c1102e7c4becc6",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-website-title-parser.json
+++ b/extensions/dragonforce2010/roam-website-title-parser.json
@@ -1,5 +1,5 @@
 {
-  "name": "Website Title Parser",
+  "name": "Power Link Parser",
   "short_description": "This extension can parse the website url title and transform the link to the markdown format when user pastes the url/link into roam block",
   "author": "Michael Zhang",
   "tags": [
@@ -7,6 +7,6 @@
   ],
   "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
   "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
-  "source_commit": "03e7c949f948f7a99a646b120af41f09337b87f9",
+  "source_commit": "414f9b437bd6e9c9d7485ca2e820a27ca3dd4bc1",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-website-title-parser.json
+++ b/extensions/dragonforce2010/roam-website-title-parser.json
@@ -1,0 +1,12 @@
+{
+  "name": "Website Title Parser",
+  "short_description": "This extension can parse the website url title and transform the link to the markdown format when user pastes the url/link into roam block",
+  "author": "Michael Zhang",
+  "tags": [
+    "markdown"
+  ],
+  "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
+  "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
+  "source_commit": "5c29ce625e3b20707ae420cc24b5b2c8dbba1a2a",
+  "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
+}

--- a/extensions/dragonforce2010/roam-website-title-parser.json
+++ b/extensions/dragonforce2010/roam-website-title-parser.json
@@ -7,6 +7,6 @@
   ],
   "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
   "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
-  "source_commit": "c94fa43c8d43ad00c42b609f1cabe32b5918f584",
+  "source_commit": "03e7c949f948f7a99a646b120af41f09337b87f9",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-website-title-parser.json
+++ b/extensions/dragonforce2010/roam-website-title-parser.json
@@ -7,6 +7,6 @@
   ],
   "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
   "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
-  "source_commit": "aacaf14df9805751d6b2a6535836a88e18253b68",
+  "source_commit": "c94fa43c8d43ad00c42b609f1cabe32b5918f584",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }


### PR DESCRIPTION
put extra check, will not transform the url to markdown format if parsed website title is blank