### PR TITLE
Update: Self destructing Blocks

### DIFF
--- a/extensions/8bitgentleman/self-destructing-blocks.json
+++ b/extensions/8bitgentleman/self-destructing-blocks.json
@@ -5,7 +5,7 @@
     "tags": ["delete"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-block-self-destruct",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-block-self-destruct.git",
-    "source_commit": "f001ef7d3fb9bb32c42cc935d49656ce64c286d0",
+    "source_commit": "c8faf4ac9f3577184e4f6cedbda0e3cbfb2f48b8",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }

--- a/extensions/8bitgentleman/self-destructing-blocks.json
+++ b/extensions/8bitgentleman/self-destructing-blocks.json
@@ -5,7 +5,7 @@
     "tags": ["delete"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-block-self-destruct",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-block-self-destruct.git",
-    "source_commit": "9c84a30c192c3e42e4c4d3a36f037f27a3bbe550",
+    "source_commit": "f001ef7d3fb9bb32c42cc935d49656ce64c286d0",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }

--- a/extensions/8bitgentleman/self-destructing-blocks.json
+++ b/extensions/8bitgentleman/self-destructing-blocks.json
@@ -5,7 +5,7 @@
     "tags": ["delete"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-block-self-destruct",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-block-self-destruct.git",
-    "source_commit": "c8faf4ac9f3577184e4f6cedbda0e3cbfb2f48b8",
+    "source_commit": "cacb91ab6695c3679adf32d453feac765d7a7f3f",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Updates from Slack feedback
-  **feat:** add⏱ in front of page links as well as tags
- **feat:** add an option to hide the self-destruct tag
-  **fix:** self-destruction blocks within templates (previously they would be deleted, defeating the whole point of the extension 🤦‍♂️)
- **fix:** update ⏱css when the self-destruct tag is changed by the user