### PR TITLE
Update: Hide Left Sidebar Items

### DIFF
--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "a5566c4dd096cf95681d6010d85c48deb03ca8aa",
+    "source_commit": "e5bc7777b16656712aeb3ee9abf130ba13f551c8",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "e5bc7777b16656712aeb3ee9abf130ba13f551c8",
+    "source_commit": "e9779613e39a7662a60e1b82d2ed9b2245c7f662",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
Two new options as requested on Slack
- Hide Shortcuts header
- Platform dependent toggle (only hide on mobile) 