### PR TITLE
Update: Fix extensionAPI Errors with hide-left-sidebar-buttons

### DIFF
--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "ed684b08955109072f2592b7813dc0883569739f",
+    "source_commit": "83b4c82686eb810c1bc0a1ac21b1662371be37db",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "e9779613e39a7662a60e1b82d2ed9b2245c7f662",
+    "source_commit": "9d24b9acf0673ee66681563655ce08d458720e34",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "9d24b9acf0673ee66681563655ce08d458720e34",
+    "source_commit": "ed684b08955109072f2592b7813dc0883569739f",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
In the production version of the extensionAPI you can't use settings id paths with some characters. This doesn't present as an issue when testing in a dev environment so I missed it
