### PR TITLE
new extension:  roam power previewer

### DIFF
--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -5,6 +5,6 @@
   "tags": ["markdown", "sidedrawer", "previewer"],
   "source_url": "https://github.com/dragonforce2010/roam-power-previewer",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "62f6762a85db7060a7dce297f73d3699e60454d8",
+  "source_commit": "efa17d0e2d720d5d4ce78c458e5248a9af4372be",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -5,6 +5,6 @@
   "tags": ["markdown", "sidedrawer", "previewer"],
   "source_url": "https://github.com/dragonforce2010/roam-power-previewer",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "99147aac855736bcbef105e72aa95d0c73e73b0c",
+  "source_commit": "62f6762a85db7060a7dce297f73d3699e60454d8",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -2,13 +2,9 @@
   "name": "Roam Power Previewer",
   "short_description": "This extension can preview a website content in the sidedrawer, which gives a better roam experience - neat clean notes and easiy preview the website content without going out of roam, to help you focus more in the roam.",
   "author": "Michael Zhang",
-  "tags": [
-    "markdown",
-    "sidedrawer",
-    "previewer"
-  ],
+  "tags": ["markdown", "sidedrawer", "previewer"],
   "source_url": "https://github.com/dragonforce2010/roam-power-previewer.git",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "5aca174edac362689f9305f18451c1a8424b04a4",
+  "source_commit": "55f660cd516fc482b1a37b6ebc9dca4a5e1b7501",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -3,8 +3,8 @@
   "short_description": "This extension can preview a website content in the sidedrawer, which gives a better roam experience - neat clean notes and easiy preview the website content without going out of roam, to help you focus more in the roam.",
   "author": "Michael Zhang",
   "tags": ["markdown", "sidedrawer", "previewer"],
-  "source_url": "https://github.com/dragonforce2010/roam-power-previewer.git",
+  "source_url": "https://github.com/dragonforce2010/roam-power-previewer",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "5cabbd00d574f54aaf0287863846a95d4800feb0",
+  "source_commit": "99147aac855736bcbef105e72aa95d0c73e73b0c",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -5,6 +5,6 @@
   "tags": ["markdown", "sidedrawer", "previewer"],
   "source_url": "https://github.com/dragonforce2010/roam-power-previewer",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "efa17d0e2d720d5d4ce78c458e5248a9af4372be",
+  "source_commit": "d86182a8a72ee5b0cacde08c942966a8a5b915ee",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -5,6 +5,6 @@
   "tags": ["markdown", "sidedrawer", "previewer"],
   "source_url": "https://github.com/dragonforce2010/roam-power-previewer",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "8136ff6323cc580c4e755df1b6da9e39320d0daf",
+  "source_commit": "336577536e3bf4a531bb984fd44650cf15bb532d",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -5,6 +5,6 @@
   "tags": ["markdown", "sidedrawer", "previewer"],
   "source_url": "https://github.com/dragonforce2010/roam-power-previewer.git",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "55f660cd516fc482b1a37b6ebc9dca4a5e1b7501",
+  "source_commit": "5cabbd00d574f54aaf0287863846a95d4800feb0",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -1,0 +1,14 @@
+{
+  "name": "Roam Power Previewer",
+  "short_description": "This extension can preview a website content in the sidedrawer, which gives a better roam experience - neat clean notes and easiy preview the website content without going out of roam, to help you focus more in the roam.",
+  "author": "Michael Zhang",
+  "tags": [
+    "markdown",
+    "sidedrawer",
+    "previewer"
+  ],
+  "source_url": "https://github.com/dragonforce2010/roam-power-previewer.git",
+  "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
+  "source_commit": "5aca174edac362689f9305f18451c1a8424b04a4",
+  "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
+}

--- a/extensions/dragonforce2010/roam-power-previewer.json
+++ b/extensions/dragonforce2010/roam-power-previewer.json
@@ -5,6 +5,6 @@
   "tags": ["markdown", "sidedrawer", "previewer"],
   "source_url": "https://github.com/dragonforce2010/roam-power-previewer",
   "source_repo": "https://github.com/dragonforce2010/roam-power-previewer.git",
-  "source_commit": "d86182a8a72ee5b0cacde08c942966a8a5b915ee",
+  "source_commit": "8136ff6323cc580c4e755df1b6da9e39320d0daf",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }


### PR DESCRIPTION
This extension can preview a website content in the sidedrawer, which gives a better roam experience - neat clean notes and easiy preview the website content without going out of roam, to help you focus more in the roam.

This extension's whole idea is to let you stay in roam to focus on your work without going out and meanwhile keep you roam notes clean, without too much blocks nested within which could disturb a lot.

For now, it can only preview the website content, but in the feature, I tend to have more contents in the roam can be previewed in the same way. Reach me out if you have any feature request.

![](https://firebasestorage.googleapis.com/v0/b/firescript-577a2.appspot.com/o/imgs%2Fapp%2FExploreSpace%2FgnDYv5fQh2.59.25.gif?alt=media&token=5b4399c6-f44f-4da4-a551-dd44b5f7a30f)