### PR TITLE
update: rename extension

### DIFF
--- a/extensions/dragonforce2010/roam-power-link-parser.json
+++ b/extensions/dragonforce2010/roam-power-link-parser.json
@@ -1,5 +1,5 @@
 {
-  "name": "Website Title Parser",
+  "name": "Roam Power Link Parser",
   "short_description": "This extension can parse the website url title and transform the link to the markdown format when user pastes the url/link into roam block",
   "author": "Michael Zhang",
   "tags": [
@@ -7,6 +7,6 @@
   ],
   "source_url": "https://github.com/dragonforce2010/roam-website-title-parser",
   "source_repo": "https://github.com/dragonforce2010/roam-website-title-parser.git",
-  "source_commit": "03e7c949f948f7a99a646b120af41f09337b87f9",
+  "source_commit": "93de3304cc0324385601b658a7a06cc640b533a6",
   "stripe_account": "acct_1MI7MVQVLQeWv9Xo"
 }


### PR DESCRIPTION
rename extension name from "Website Title Parser" to "Roam Power Link Parser"