### PR TITLE
Update self-destructing-blocks.json

### DIFF
--- a/extensions/8bitgentleman/self-destructing-blocks.json
+++ b/extensions/8bitgentleman/self-destructing-blocks.json
@@ -5,7 +5,7 @@
     "tags": ["delete"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-block-self-destruct",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-block-self-destruct.git",
-    "source_commit": "cacb91ab6695c3679adf32d453feac765d7a7f3f",
+    "source_commit": "d53a79e843f95757a5ac0b99c9b732a9a770b4dd",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }

--- a/extensions/8bitgentleman/self-destructing-blocks.json
+++ b/extensions/8bitgentleman/self-destructing-blocks.json
@@ -5,7 +5,7 @@
     "tags": ["delete"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-block-self-destruct",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-block-self-destruct.git",
-    "source_commit": "d53a79e843f95757a5ac0b99c9b732a9a770b4dd",
+    "source_commit": "135262d3d77b62de212773f2fe36262e48be9165",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Fix a typo which caused issues with SmartBlock template detection 
Adds an optional log page, per a request on slack. First test for including a `Changelog.md` in the repo as well. 