### PR TITLE
Fix format-blocks-hotkey.json

### DIFF
--- a/extensions/8bitgentleman/format-blocks-hotkey.json
+++ b/extensions/8bitgentleman/format-blocks-hotkey.json
@@ -1,6 +1,6 @@
 {
     "name": "Format Block Hotkeys",
-    "short_description": "Adds hotkeys for various block formatting options.",
+    "short_description": "Adds configurable hotkeys for various block formatting options to the Roam command palette and the Roam native hotkey page.",
     "author": "Matt Vogel",
     "tags": ["blocks", "formatting"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-format-hotkeys",

--- a/extensions/8bitgentleman/format-blocks-hotkey.json
+++ b/extensions/8bitgentleman/format-blocks-hotkey.json
@@ -5,6 +5,6 @@
     "tags": ["blocks", "formatting"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-format-hotkeys",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-format-hotkeys.git",
-    "source_commit": "def877c8f6a3ddc6511ab1d6c87ea49f72f9e338",
+    "source_commit": "45a1445b82a23661361872f6c5ffeeba5aacb5ba",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/format-blocks-hotkey.json
+++ b/extensions/8bitgentleman/format-blocks-hotkey.json
@@ -1,6 +1,6 @@
 {
     "name": "Format Block Hotkeys",
-    "short_description": "Adds configurable hotkeys for various block formatting options to the Roam command palette and the Roam native hotkey page.",
+    "short_description": "Adds configurable hotkeys for various block formatting options to the Roam command palette and the native Roam hotkey page.",
     "author": "Matt Vogel",
     "tags": ["blocks", "formatting"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-format-hotkeys",


### PR DESCRIPTION
When blocks are created sometimes metadata is omitted and default styling is assumed. This caused a silent failure of the extension