### PR TITLE
New Extension: Todo progress bar - Roam/Render component

### DIFF
--- a/extensions/8bitgentleman/todo-progress-bar.json
+++ b/extensions/8bitgentleman/todo-progress-bar.json
@@ -5,6 +5,6 @@
     "tags": ["roam/render", "TODO", "CSS"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-todo-progress-bar",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-todo-progress-bar.git",
-    "source_commit": "8d93bc5773a237080239f024bec94cd87526a56c",
+    "source_commit": "bd8b65aa6e41e691f3ce2e9b7109c709622564d7",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }

--- a/extensions/8bitgentleman/todo-progress-bar.json
+++ b/extensions/8bitgentleman/todo-progress-bar.json
@@ -1,0 +1,10 @@
+{
+    "name": "TODO Progress Bar",
+    "short_description": "Roam Research progress bar component for visually tracking TODOs in a list.",
+    "author": "Matt Vogel",
+    "tags": ["roam/render", "TODO", "CSS"],
+    "source_url": "https://github.com/8bitgentleman/roam-depot-todo-progress-bar",
+    "source_repo": "https://github.com/8bitgentleman/roam-depot-todo-progress-bar.git",
+    "source_commit": "8d93bc5773a237080239f024bec94cd87526a56c",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+  }


### PR DESCRIPTION
This is the first extension (I believe) that adds a roam/render component to a user's graph. The idea is to re-load the roam/render codeblock on graph load which preserves a user's existing render references while keeping the ability for me to update the cljs code