### PR TITLE
Adds PR Shorthand to the "comment" Github Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ firebase-key.json
 node_modules
 checkout/*
 !checkout/.keep
+
+.clj-kondo
+.cpcache
+.lsp

--- a/src/community_extensions/comment.clj
+++ b/src/community_extensions/comment.clj
@@ -37,7 +37,7 @@
                            (for [[mode path] changes
                                  :let [[_ user repo] (re-matches #"extensions/([^/]+)/([^/]+)\.json" path)
                                        pr-shorthand  (str user "+" repo "+" pr)
-                                       pr-shorthand-msg (str " (PR shorthand: `" pr-shorthand "`) ")
+                                       pr-shorthand-msg (str " (PR-shorthand: `" pr-shorthand "`) ")
                                        commit-before (:source_commit (before path))
                                        commit-after  (:source_commit (after path))
                                        url (or (:source_url (before path))

--- a/src/community_extensions/comment.clj
+++ b/src/community_extensions/comment.clj
@@ -36,6 +36,8 @@
                            ["Here’s your link to the diff:\n"]
                            (for [[mode path] changes
                                  :let [[_ user repo] (re-matches #"extensions/([^/]+)/([^/]+)\.json" path)
+                                       pr-shorthand  (str user "+" repo "+" pr)
+                                       pr-shorthand-msg (str " (PR shorthand: `" pr-shorthand "`) ")
                                        commit-before (:source_commit (before path))
                                        commit-after  (:source_commit (after path))
                                        url (or (:source_url (before path))
@@ -43,13 +45,13 @@
                                  :when (not= commit-before commit-after)]
                              (cond
                                (nil? commit-before)
-                               (str "Added [" user "/" repo "](" url ") [" (subs commit-after 0 7) "](" url "/tree/" commit-after ")")
+                               (str "Added [" user "/" repo "](" url ") [" (subs commit-after 0 7) "](" url "/tree/" commit-after ")" pr-shorthand-msg)
                                
                                (nil? commit-after)
-                               (str "Added [" user "/" repo "](" url ") [" (subs commit-before 0 7) "](" url "/tree/" commit-before ")")
+                               (str "Added [" user "/" repo "](" url ") [" (subs commit-before 0 7) "](" url "/tree/" commit-before ")" pr-shorthand-msg)
                                
                                :else
-                               (str "Changed [" user "/" repo "](" url ") [" (subs commit-before 0 7) " → " (subs commit-after 0 7) "](" url "/compare/" commit-before ".." commit-after ")")))))]
+                               (str "Changed [" user "/" repo "](" url ") [" (subs commit-before 0 7) " → " (subs commit-after 0 7) "](" url "/compare/" commit-before ".." commit-after ")" pr-shorthand-msg)))))]
     (println message)
     (when token
       (http/post (str "https://api.github.com/repos/Roam-Research/roam-depot/issues/" pr "/comments")


### PR DESCRIPTION
This change adds PR shorthand to the Comment Github Action that runs when PR is created / updated. 
Idea is that this can then be used to load a remote developer extension. 
For more detail on remote developer extensions: https://roamresearch.com/#/app/developer-documentation/page/n8ECay0Wl

Highlighted bit in screenshot below is the addition to the markdown content of the comment

<img width="1447" alt="image" src="https://user-images.githubusercontent.com/23657255/234490150-2f519e4b-a66c-4597-8a13-9a6f1e332fee.png">

Don't know how/ if I can test in production, but given that it works locally, see no reason why it would not work in prod