### PR TITLE
Important fix: Page References Counter

### DIFF
--- a/extensions/fbgallet/roam-extension-ref-count.json
+++ b/extensions/fbgallet/roam-extension-ref-count.json
@@ -1,10 +1,10 @@
 {
   "name": "Page references counter",
-  "short_description": "Page references counter, visible inline and in search box + see if page is empty or not.",
+  "short_description": "Page references counter, visible inline and in search box + empty/not empty page indicator.",
   "author": "Fabrice Gallet",
   "tags": ["page", "reference", "mention", "count", "alias"],
   "source_url": "https://github.com/fbgallet/roam-extension-ref-count",
   "source_repo": "https://github.com/fbgallet/roam-extension-ref-count.git",
-  "source_commit": "82bab9e5118fb9331e2b51d4ceeccaebd236c151",
+  "source_commit": "16b1bdb9ef706ec27b9576a1f865e3d6642d6827",
   "stripe_account": "acct_1LJHuRQerhPsAmG6"
 }

--- a/extensions/fbgallet/roam-extension-ref-count.json
+++ b/extensions/fbgallet/roam-extension-ref-count.json
@@ -1,6 +1,6 @@
 {
   "name": "Page references counter",
-  "short_description": "Inline and in search box page references counter, similar to native inline block references counter.",
+  "short_description": "Page references counter, visible inline and in search box, similar to native inline block references counter.",
   "author": "Fabrice Gallet",
   "tags": ["page", "reference", "mention", "count", "alias"],
   "source_url": "https://github.com/fbgallet/roam-extension-ref-count",

--- a/extensions/fbgallet/roam-extension-ref-count.json
+++ b/extensions/fbgallet/roam-extension-ref-count.json
@@ -5,6 +5,6 @@
   "tags": ["page", "reference", "mention", "count", "alias"],
   "source_url": "https://github.com/fbgallet/roam-extension-ref-count",
   "source_repo": "https://github.com/fbgallet/roam-extension-ref-count.git",
-  "source_commit": "2f69d169f3ab4aa2cc88c143058a561733bb7aa2",
+  "source_commit": "c49a8a8304b734d997e14b4bac95911951f639ca",
   "stripe_account": "acct_1LJHuRQerhPsAmG6"
 }

--- a/extensions/fbgallet/roam-extension-ref-count.json
+++ b/extensions/fbgallet/roam-extension-ref-count.json
@@ -1,10 +1,10 @@
 {
   "name": "Page references counter",
-  "short_description": "Page references counter, visible inline and in search box, similar to native inline block references counter.",
+  "short_description": "Page references counter, visible inline and in search box + see if page is empty or not.",
   "author": "Fabrice Gallet",
   "tags": ["page", "reference", "mention", "count", "alias"],
   "source_url": "https://github.com/fbgallet/roam-extension-ref-count",
   "source_repo": "https://github.com/fbgallet/roam-extension-ref-count.git",
-  "source_commit": "c49a8a8304b734d997e14b4bac95911951f639ca",
+  "source_commit": "82bab9e5118fb9331e2b51d4ceeccaebd236c151",
   "stripe_account": "acct_1LJHuRQerhPsAmG6"
 }


### PR DESCRIPTION
@panterarocks49 some users have experienced app freezing with the previous version, on page with a large amout of linked references. This commit should fix the issue.