### PR TITLE
improve compatibility between Reference Path and Sticky Headings extensions

### DIFF
--- a/extensions/paulovieira/reference-path.json
+++ b/extensions/paulovieira/reference-path.json
@@ -5,6 +5,6 @@
 	"tags": ["reference path"],
 	"source_url": "https://github.com/paulovieira/roam-reference-path",
 	"source_repo": "https://github.com/paulovieira/roam-reference-path.git",
-	"source_commit": "189c154cd5c1d0a78b202a08fa1f0e95d9df4593",
+	"source_commit": "1cf41cb157edf55f06860cb52bfecb921f5fa020",
 	"stripe_account": "acct_1Lgr9KQYMxcp1XA2"
 }


### PR DESCRIPTION
More details here: https://github.com/paulovieira/roam-reference-path/issues/19