### PR TITLE
Update switch+

### DIFF
--- a/extensions/hyc/switch+.json
+++ b/extensions/hyc/switch+.json
@@ -4,6 +4,6 @@
       "author": "hyc",
       "source_url": "https://github.com/dive2Pro/roam-switch-plus",
       "source_repo": "https://github.com/dive2Pro/roam-switch-plus.git",
-      "source_commit": "7d6d20df62199fc9a4a11275ccaedc144bbb006a",
+      "source_commit": "6c1ebb024afa5eb52aca8a8bcbca92c9726f235f",
       "stripe_account": "acct_1LLkJkQbYbNOfzpa"
     }            


### PR DESCRIPTION
1. Support Tab and Shift+Tab to zoom-in and zoom-out in a block
2. show filtered/total in the bottom 
3. remove the #el when uninstall the plugin 
4. fix https://github.com/dive2Pro/roam-switch-plus/issues/2 and https://github.com/dive2Pro/roam-switch-plus/issues/1