### PR TITLE
New Extension: Save Scrollbar Position

### DIFF
--- a/extensions/studyduck/roam-save-scrollbar-position.json
+++ b/extensions/studyduck/roam-save-scrollbar-position.json
@@ -5,5 +5,5 @@
   "tags": ["scrollbar"],
   "source_url": "https://github.com/studyduck/roam-save-scrollbar-position",
   "source_repo": "https://github.com/studyduck/roam-save-scrollbar-position.git",
-  "source_commit": "91d00cd92d6d41a0ed817bac9e17304ec1e61e44"
+  "source_commit": "f0c1651c6358bc9aa4268115a3a9c051c694540e"
 }

--- a/extensions/studyduck/roam-save-scrollbar-position.json
+++ b/extensions/studyduck/roam-save-scrollbar-position.json
@@ -5,5 +5,5 @@
   "tags": ["scrollbar"],
   "source_url": "https://github.com/studyduck/roam-save-scrollbar-position",
   "source_repo": "https://github.com/studyduck/roam-save-scrollbar-position.git",
-  "source_commit": "260aa302d9e93b4530b5691cee173e8ae73e0003"
+  "source_commit": "91d00cd92d6d41a0ed817bac9e17304ec1e61e44"
 }

--- a/extensions/studyduck/roam-save-scrollbar-position.json
+++ b/extensions/studyduck/roam-save-scrollbar-position.json
@@ -1,0 +1,9 @@
+{
+  "name": "Save Scrollbar Position",
+  "short_description": "Saves the scrollbar position of a page when you leave it and restores it when you return.",
+  "author": "studyduck",
+  "tags": ["scrollbar"],
+  "source_url": "https://github.com/studyduck/roam-save-scrollbar-position",
+  "source_repo": "https://github.com/studyduck/roam-save-scrollbar-position.git",
+  "source_commit": "260aa302d9e93b4530b5691cee173e8ae73e0003"
+}


### PR DESCRIPTION
Save Scrollbar Position-Saves the scrollbar position of a page when you leave it and restores it when you return