### PR TITLE
Matter 1.1.0

### DIFF
--- a/extensions/getmatterapp/matter.json
+++ b/extensions/getmatterapp/matter.json
@@ -4,5 +4,5 @@
   "author": "The Matter Team",
   "source_url": "https://github.com/getmatterapp/roam-matter",
   "source_repo": "https://github.com/getmatterapp/roam-matter.git",
-  "source_commit": "3cd9c763ef2e2dccbf7cd2714d2cee7980d9d743"
+  "source_commit": "4ca9d34bcf3c7bc96e3f375575a8b6318d844399"
 }

--- a/extensions/getmatterapp/matter.json
+++ b/extensions/getmatterapp/matter.json
@@ -4,5 +4,5 @@
   "author": "The Matter Team",
   "source_url": "https://github.com/getmatterapp/roam-matter",
   "source_repo": "https://github.com/getmatterapp/roam-matter.git",
-  "source_commit": "a5d42a4ada7985959c29dc827d05979cdffbc5a2"
+  "source_commit": "3cd9c763ef2e2dccbf7cd2714d2cee7980d9d743"
 }


### PR DESCRIPTION
Migrates the "sync to daily note" setting to a "sync locations" selector. The user will be able to select between syncing to:
1. Only an article page
2. Only the daily note
3. Both the article page and daily note