### PR TITLE
New Extension:Tag-cycle Component.json

### DIFF
--- a/extensions/8bitgentleman/tag-cycle-component.json
+++ b/extensions/8bitgentleman/tag-cycle-component.json
@@ -1,0 +1,10 @@
+{
+    "name": "Tag Cycle Component",
+    "short_description": "Roam Research component to cycle through a list of tags or pages with a click.",
+    "author": "Matt Vogel",
+    "tags": ["roam/render", "component", "tags"],
+    "source_url": "https://github.com/8bitgentleman/roam-depot-tag-cycle",
+    "source_repo": "https://github.com/8bitgentleman/roam-depot-tag-cycle.git",
+    "source_commit": "fda86c9fb6c46a72e56dc37795c27b329a4d8e0c",
+    "stripe_account": "acct_1LJFEYQmxalymEZL"
+  }

--- a/extensions/8bitgentleman/tag-cycle-component.json
+++ b/extensions/8bitgentleman/tag-cycle-component.json
@@ -5,6 +5,6 @@
     "tags": ["roam/render", "component", "tags"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-tag-cycle",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-tag-cycle.git",
-    "source_commit": "fda86c9fb6c46a72e56dc37795c27b329a4d8e0c",
+    "source_commit": "5e40ac785e7abdafc91f4586a039d6c47e9d1087",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
A roam/render component to cycle through a block ref'd list of tags
![example2](https://github.com/Roam-Research/roam-depot/assets/4028391/5d5f5bf0-69c5-415c-b096-c88706ce24d0)
![example3](https://github.com/Roam-Research/roam-depot/assets/4028391/4dad5ea2-3151-4e98-99be-7e5a673a47e8)
