### PR TITLE
Update Quick Capture Companion

### DIFF
--- a/extensions/mlava/quick-capture-companion.json
+++ b/extensions/mlava/quick-capture-companion.json
@@ -5,6 +5,6 @@
   "tags": ["capture", "ios", "android"],
   "source_url": "https://github.com/mlava/quick-capture-companion",
   "source_repo": "https://github.com/mlava/quick-capture-companion.git",
-  "source_commit": "be69c9a5d4c6eebc49dcc7ef332a23c1080aa8e9",
+  "source_commit": "40dc2ecbdbb646bc06d1aa358c3f3bd1ebfc2ece",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
@baibhavbista @panterarocks49 

This version handles image upload from my app to RR:

- app uploads images to Cloudinary and posts cloudinary URL to graph via API
- this extension checks for cloudinary URLs and then calls a heroku server (my own)
- Heroku server sends the image to be uploaded to Firebase via Roam frontend API, then deletes image at Cloudinary
- this extension then updates the link in graph to point to firebase url