### PR TITLE
adding back missing metadata to hyc tabs

### DIFF
--- a/extensions/hyc/Tabs+.json
+++ b/extensions/hyc/Tabs+.json
@@ -1,9 +1,9 @@
     {
-      "name": "",
-      "short_description": "",
-      "author": "",
+      "name": "Roam Tabs",
+      "short_description": "A plugin that allows you to organize the pages you're working on into tabs.",
+      "author": "hyc",
       "source_url": "https://github.com/dive2Pro/roam-tabs",
       "source_repo": "https://github.com/dive2Pro/roam-tabs.git",
       "source_commit": "7ad0805085b0629eea3c485cb9984e202a4f9f05",
-      "stripe_account": ""
+      "stripe_account": "acct_1LLkJkQbYbNOfzpa"
     }            


### PR DESCRIPTION
@dive2Pro  mistakenly removed the metadata in #761 
<img width="1695" alt="image" src="https://github.com/Roam-Research/roam-depot/assets/23657255/770ecdc8-f2da-4f44-9733-930b9e29cd73">
