### PR TITLE
Update send-to-graph.json

### DIFF
--- a/extensions/8bitgentleman/send-to-graph.json
+++ b/extensions/8bitgentleman/send-to-graph.json
@@ -5,7 +5,7 @@
     "tags": ["Backend API"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-send-to-graph",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-send-to-graph.git",
-    "source_commit": "afc89b4dead9203bacdf0d655a1060885ff43715",
+    "source_commit": "4451793fde33f42115abae98fdbf616bca3a62dc",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Now block refs and block embeds are resolved before sending. To avoid broken refs