### PR TITLE
Update Translate extension

### DIFF
--- a/extensions/mlava/translate.json
+++ b/extensions/mlava/translate.json
@@ -5,6 +5,6 @@
   "tags": ["translate", "text"],
   "source_url": "https://github.com/mlava/translate",
   "source_repo": "https://github.com/mlava/translate.git",
-  "source_commit": "265b7941197f335c3d0e4b8035ed3032e80b4413",
+  "source_commit": "30c69ebb9911afb7eef35229643d08ad4d9d7ac8",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
Fix to prompt user for source language instead of using detect via the API. API is now charging for detect calls but not translate calls.