### PR TITLE
add block-share-card extension metafile

### DIFF
--- a/extensions/qcrao/block-share-card.json
+++ b/extensions/qcrao/block-share-card.json
@@ -1,0 +1,10 @@
+{
+  "name": "Block Share Card",
+  "short_description": "Allows users to share Roam Research blocks as images optimized for mobile and desktop devices.",
+  "author": "qcrao",
+  "tags": ["sharing", "productivity", "images"],
+  "source_url": "https://github.com/qcrao/block-share-card",
+  "source_repo": "https://github.com/qcrao/block-share-card.git",
+  "source_commit": "e0e2d190bbd547935db5972d23b5da21959b3faf",
+  "stripe_account": "acct_1PJTCpQd6q6JNEre"
+}

--- a/extensions/qcrao/block-share-card.json
+++ b/extensions/qcrao/block-share-card.json
@@ -5,6 +5,6 @@
   "tags": ["sharing", "productivity", "images"],
   "source_url": "https://github.com/qcrao/block-share-card",
   "source_repo": "https://github.com/qcrao/block-share-card.git",
-  "source_commit": "e0e2d190bbd547935db5972d23b5da21959b3faf",
+  "source_commit": "080bf3be8014739e8be49fe5a1bca66b57119155",
   "stripe_account": "acct_1PJTCpQd6q6JNEre"
 }

--- a/extensions/qcrao/block-share-card.json
+++ b/extensions/qcrao/block-share-card.json
@@ -5,6 +5,6 @@
   "tags": ["sharing", "productivity", "images"],
   "source_url": "https://github.com/qcrao/block-share-card",
   "source_repo": "https://github.com/qcrao/block-share-card.git",
-  "source_commit": "080bf3be8014739e8be49fe5a1bca66b57119155",
+  "source_commit": "a9f64af70b8048dba60595d5f9ae72d2d2e7067f",
   "stripe_account": "acct_1PJTCpQd6q6JNEre"
 }

--- a/extensions/qcrao/block-share-card.json
+++ b/extensions/qcrao/block-share-card.json
@@ -5,6 +5,6 @@
   "tags": ["sharing", "productivity", "images"],
   "source_url": "https://github.com/qcrao/block-share-card",
   "source_repo": "https://github.com/qcrao/block-share-card.git",
-  "source_commit": "a9f64af70b8048dba60595d5f9ae72d2d2e7067f",
+  "source_commit": "84a61bcc30399b4842443fdc7c105649bc0694d2",
   "stripe_account": "acct_1PJTCpQd6q6JNEre"
 }


### PR DESCRIPTION
This PR introduces the Block Share Card extension for Roam Research. 

This extension allows users to easily share content blocks from Roam Research as images optimized for mobile and desktop viewing. The functionality enhances the user experience by providing a quick and efficient way to share information in a visually appealing format.
