### PR TITLE
FIX: silent failure sending blocks

### DIFF
--- a/extensions/8bitgentleman/send-to-graph.json
+++ b/extensions/8bitgentleman/send-to-graph.json
@@ -5,7 +5,7 @@
     "tags": ["Backend API"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-send-to-graph",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-send-to-graph.git",
-    "source_commit": "4451793fde33f42115abae98fdbf616bca3a62dc",
+    "source_commit": "57579c38c02b2b99461376a4cef68e40cfb83b7f",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Send-to-graph sometimes silently failed while showing success. This happened because we were not awaiting a response from the roam backend