### PR TITLE
Update format-blocks-hotkey.json

### DIFF
--- a/extensions/8bitgentleman/format-blocks-hotkey.json
+++ b/extensions/8bitgentleman/format-blocks-hotkey.json
@@ -5,6 +5,6 @@
     "tags": ["blocks", "formatting"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-format-hotkeys",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-format-hotkeys.git",
-    "source_commit": "45a1445b82a23661361872f6c5ffeeba5aacb5ba",
+    "source_commit": "f16afc67e6e46a530ec21346c12e5cd0a2bf1374",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
Adds an option to cycle through a block's children's view type with a single shortcut