### PR TITLE
Update block-distributor.json

### DIFF
--- a/extensions/8bitgentleman/block-distributor.json
+++ b/extensions/8bitgentleman/block-distributor.json
@@ -5,7 +5,7 @@
     "tags": ["automation"],
     "source_url": "https://github.com/8bitgentleman/roam-depo-block-distribution",
     "source_repo": "https://github.com/8bitgentleman/roam-depo-block-distribution.git",
-    "source_commit": "6ea5b1a1dcc68d0a1fd13b746c00eb1583a1526f",
+    "source_commit": "96a274655d5a273381428c212aff65aee3b8db4f",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
 
 }


### PR DESCRIPTION
Add the options to 
- send a block embed instead of a block ref
- fully move the block structure (with/without leaving a reference behind)