### PR TITLE
Add TODO Analysis extension

### DIFF
--- a/extensions/forrestchang/roam-todo-analysis.json
+++ b/extensions/forrestchang/roam-todo-analysis.json
@@ -1,0 +1,9 @@
+{
+  "name": "TODO Analysis", 
+  "short_description": "Analyze TODO blocks in your Roam graph, providing insights and statistics on task patterns and completion rates.",
+  "author": "Forrest Chang",
+  "tags": ["todo", "statistics", "analysis", "productivity"],
+  "source_url": "https://github.com/forrestchang/roam-todo-analysis",
+  "source_repo": "https://github.com/forrestchang/roam-todo-analysis.git",
+  "source_commit": "c317f3cd57fc90afc681d78c6951d786a7f31b90"
+}


### PR DESCRIPTION
## Summary
- Adds metadata for the TODO Analysis extension by Forrest Chang
- Extension provides insights and statistics on TODO blocks in Roam graphs
- Repository: https://github.com/forrestchang/roam-todo-analysis

## Test plan
- [x] Metadata file follows the correct format
- [x] All required fields are present
- [x] Source repository is accessible
- [x] Commit hash is valid

🤖 Generated with [Claude Code](https://claude.ai/code)