### PR TITLE
Update: roam-references-radar  

### DIFF
--- a/extensions/hyc/roam-references-radar.json
+++ b/extensions/hyc/roam-references-radar.json
@@ -4,6 +4,6 @@
       "author": "hyc",
       "source_url": "https://github.com/dive2Pro/roam-references-radar",
       "source_repo": "https://github.com/dive2Pro/roam-references-radar.git",
-      "source_commit": "2a6cb63cd0bb2c1ca81e85ecdbd70c33ce20165e",
+      "source_commit": "d4e2a970a0a3876f58c676c38c95146eb0c04044",
       "stripe_account": "acct_1LLkJkQbYbNOfzpa"
     }            


### PR DESCRIPTION
**Link All Feature**: Click the "Link All Preview" button in the popover to see a preview of all keywords converted to reference links at once. Review the changes and click "Confirm" to apply all links, or "Cancel" to revert.