### PR TITLE
Update hide-left-sidebar-buttons.json

### DIFF
--- a/extensions/8bitgentleman/hide-left-sidebar-buttons.json
+++ b/extensions/8bitgentleman/hide-left-sidebar-buttons.json
@@ -5,6 +5,6 @@
     "tags": ["left sidebar"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-hide-left-sidebar-buttons.git",
-    "source_commit": "83b4c82686eb810c1bc0a1ac21b1662371be37db",
+    "source_commit": "f7f3874b20151d8c42bcf68217f2359a7423c2d7",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
Update the extension to use the roam depot extension api so that settings persist across devices