### PR TITLE
New Extension: quick-copy-block-link

### DIFF
--- a/extensions/MannixHu/roam-quick-copy-block-link.json
+++ b/extensions/MannixHu/roam-quick-copy-block-link.json
@@ -4,5 +4,5 @@
   "author": "@MannixHu",
   "source_url": "https://github.com/MannixHu/roam-depot-quick-copy-block-link",
   "source_repo": "https://github.com/MannixHu/roam-depot-quick-copy-block-link.git",
-  "source_commit": "83af755bac9ce82eb2989650c2d737a0daf62a37"
+  "source_commit": "48a7d3d12b614f034d9fac22b5cb9f40fd171d18"
 }

--- a/extensions/MannixHu/roam-quick-copy-block-link.json
+++ b/extensions/MannixHu/roam-quick-copy-block-link.json
@@ -1,0 +1,8 @@
+{
+  "name": "quick-copy-block-link",
+  "short_description": "quick copy block/page desktop link in markdown format",
+  "author": "@MannixHu",
+  "source_url": "https://github.com/MannixHu/roam-depot-quick-copy-block-link",
+  "source_repo": "https://github.com/MannixHu/roam-depot-quick-copy-block-link.git",
+  "source_commit": "83af755bac9ce82eb2989650c2d737a0daf62a37"
+}

--- a/extensions/MannixHu/roam-quick-copy-block-link.json
+++ b/extensions/MannixHu/roam-quick-copy-block-link.json
@@ -4,5 +4,5 @@
   "author": "@MannixHu",
   "source_url": "https://github.com/MannixHu/roam-depot-quick-copy-block-link",
   "source_repo": "https://github.com/MannixHu/roam-depot-quick-copy-block-link.git",
-  "source_commit": "48a7d3d12b614f034d9fac22b5cb9f40fd171d18"
+  "source_commit": "d284def11a67bb1d0898ad1ea76a020166b17e81"
 }


### PR DESCRIPTION
quick copy block / page desktop link in markdown format
copy such as `[block text or page title](roam://#/app/userxx/page/CovCrrQRU)`
Entrance: 1. right click menu [Extensions - copy desktop link as markdown]  2. shortcut Hotkey