### PR TITLE
Update Chief Of Staff

### DIFF
--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "c9167bbf4bf231fda82b5ee4d1cf8cb71d6ed55a",
+  "source_commit": "c87de11ca800745c9a981d5b7364c961e5a8aaf7",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "7197133c060a328f757db815d5a73a860429685c",
+  "source_commit": "2e7fffde086ecf963476e8dd93dae8badefac76e",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "268eaf377dc8ec2a4dab881b9ed86c74ef8eb87b",
+  "source_commit": "ca36dc67eb36ba9f7412b4c9bf0dc2d148b52540",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "c87de11ca800745c9a981d5b7364c961e5a8aaf7",
+  "source_commit": "7197133c060a328f757db815d5a73a860429685c",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "86c5cc9f25e651abe95bc176b9a6b0435b468d35",
+  "source_commit": "268eaf377dc8ec2a4dab881b9ed86c74ef8eb87b",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "96ab8cbf3881f74308edf49928a050ff9228d78a",
+  "source_commit": "86c5cc9f25e651abe95bc176b9a6b0435b468d35",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "ca36dc67eb36ba9f7412b4c9bf0dc2d148b52540",
+  "source_commit": "abf39da9c59b7b7f133669d723bfb6ee4a814f7b",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "f9488b806e8c4d081ec674024f08aec640897585",
+  "source_commit": "c9167bbf4bf231fda82b5ee4d1cf8cb71d6ed55a",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "abf39da9c59b7b7f133669d723bfb6ee4a814f7b",
+  "source_commit": "f9488b806e8c4d081ec674024f08aec640897585",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
- Add intent confidence gate: lightweight LLM classification before agent loop to catch ambiguous/high-risk queries before burning tokens 
- Fix meta-tool dispatch: EXT_ROUTE, EXT_EXECUTE, ROAM_ROUTE, ROAM_EXECUTE had no execution path — fell through to Composio MCP which returned "Tool not found" 
- Fix Composio slug interceptor hijacking remote MCP tools: when a service (e.g. Gmail) is connected via Remote MCP, stale Composio registry entries no longer intercept those tool calls 
- Add remote MCP servers to tool discovery (cos_get_tool_ecosystem, COMPOSIO_GET_CONNECTED_ACCOUNTS) 
- Add remote MCP argument auto-correction for common parameter mismatches (array→string, timeMin↔dateMin bidirectional mapping) 
