### PR TITLE
Update Better Tasks

### DIFF
--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "3aecda4dd3f62dfbb15b11ce50a051b2dd80b36d",
+  "source_commit": "80f32209d68069dc58a52e3eb4c8040d2013aea1",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "80f32209d68069dc58a52e3eb4c8040d2013aea1",
+  "source_commit": "36c5459f2ee06ce6a50c60bef03d181b8ec0752c",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "36c5459f2ee06ce6a50c60bef03d181b8ec0752c",
+  "source_commit": "4806615643ec7b429105f66a5587483993b6c51f",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "d3c66f4974fe0a6956564b68737d331b6f2dc3c9",
+  "source_commit": "7c477e31a564df7a33c785d15c468e15c7d972de",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "7c477e31a564df7a33c785d15c468e15c7d972de",
+  "source_commit": "3aecda4dd3f62dfbb15b11ce50a051b2dd80b36d",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "4806615643ec7b429105f66a5587483993b6c51f",
+  "source_commit": "002eb538bda6b23021aae4611830a043194668f9",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
Dashboard: 
- render markdown links and page refs in task titles
- fix waiting-for filter matching 

Summary:
- Markdown links ([text](url)) in task titles now render as clickable links in the dashboard (opens in new tab) 
- Page refs ([[page name]]) in task titles now render as clickable tag-like buttons — click navigates to the page in the main window, shift+click opens in the right sidebar 
- Fixed waiting-for filter mismatch — normalizeWaitingValue() was not stripping [[brackets]] like the project and context stores already do, causing the filter dropdown to show [[Elon Musk]] which then failed to match the stripped task metadata value 