### PR TITLE
Add Roam Toolkit Vim Mode extension

### DIFF
--- a/extensions/Stvad/roam-vim-navigation.json
+++ b/extensions/Stvad/roam-vim-navigation.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/Stvad/roam-vim-navigation",
   "source_repo": "https://github.com/Stvad/roam-vim-navigation.git",
-  "source_commit": "7ffd05938301588f2bc9de67fe66ed8c2224bdd8",
+  "source_commit": "923a29b913c4d7eb49c320f68098e478b9e8372c",
   "stripe_account": "acct_1LcbYoQmU9n2q3gV"
 }

--- a/extensions/Stvad/roam-vim-navigation.json
+++ b/extensions/Stvad/roam-vim-navigation.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/Stvad/roam-vim-navigation",
   "source_repo": "https://github.com/Stvad/roam-vim-navigation.git",
-  "source_commit": "c05674379bd1dbe938577b6b01b620df8ffb5514",
+  "source_commit": "e7a3ac3649d1440f4810f858952328ec8f3969f6",
   "stripe_account": "acct_1LcbYoQmU9n2q3gV"
 }

--- a/extensions/Stvad/roam-vim-navigation.json
+++ b/extensions/Stvad/roam-vim-navigation.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/Stvad/roam-vim-navigation",
   "source_repo": "https://github.com/Stvad/roam-vim-navigation.git",
-  "source_commit": "923a29b913c4d7eb49c320f68098e478b9e8372c",
+  "source_commit": "140454db40fd3fa7e3dbd430a19dffa3da9c1af3",
   "stripe_account": "acct_1LcbYoQmU9n2q3gV"
 }

--- a/extensions/Stvad/roam-vim-navigation.json
+++ b/extensions/Stvad/roam-vim-navigation.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/Stvad/roam-vim-navigation",
   "source_repo": "https://github.com/Stvad/roam-vim-navigation.git",
-  "source_commit": "3dffa35e46ad258d6282b4cb2498a84ca0d6e316",
+  "source_commit": "7ffd05938301588f2bc9de67fe66ed8c2224bdd8",
   "stripe_account": "acct_1LcbYoQmU9n2q3gV"
 }

--- a/extensions/Stvad/roam-vim-navigation.json
+++ b/extensions/Stvad/roam-vim-navigation.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/Stvad/roam-vim-navigation",
   "source_repo": "https://github.com/Stvad/roam-vim-navigation.git",
-  "source_commit": "e7a3ac3649d1440f4810f858952328ec8f3969f6",
+  "source_commit": "3dffa35e46ad258d6282b4cb2498a84ca0d6e316",
   "stripe_account": "acct_1LcbYoQmU9n2q3gV"
 }

--- a/extensions/Stvad/roam-vim-navigation.json
+++ b/extensions/Stvad/roam-vim-navigation.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/Stvad/roam-vim-navigation",
   "source_repo": "https://github.com/Stvad/roam-vim-navigation.git",
-  "source_commit": "140454db40fd3fa7e3dbd430a19dffa3da9c1af3",
+  "source_commit": "343937001af94c1c465f3218b27d16c016db2bf1",
   "stripe_account": "acct_1LcbYoQmU9n2q3gV"
 }

--- a/extensions/Stvad/roam-vim-navigation.json
+++ b/extensions/Stvad/roam-vim-navigation.json
@@ -1,0 +1,15 @@
+{
+  "name": "Roam Toolkit Vim Mode",
+  "short_description": "Vim-like block navigation and editing shortcuts for Roam Research.",
+  "author": "Vlad Sitalo",
+  "tags": [
+    "navigation",
+    "keyboard",
+    "editing",
+    "vim"
+  ],
+  "source_url": "https://github.com/Stvad/roam-vim-navigation",
+  "source_repo": "https://github.com/Stvad/roam-vim-navigation.git",
+  "source_commit": "c05674379bd1dbe938577b6b01b620df8ffb5514",
+  "stripe_account": "acct_1LcbYoQmU9n2q3gV"
+}


### PR DESCRIPTION
## Summary
- add the Roam Toolkit Vim Mode extension metadata
- point roam-depot at the published source repo and commit c05674379bd1dbe938577b6b01b620df8ffb5514
- reuse existing Stvad marketplace author and stripe account metadata
