### PR TITLE
Add History of Today extension

### DIFF
--- a/extensions/laixintao/roam-research-history-of-today.json
+++ b/extensions/laixintao/roam-research-history-of-today.json
@@ -1,0 +1,9 @@
+{
+    "name": "History of Today",
+    "short_description": "Adds \"On this day\" buttons to the calendar popover to jump to past years' daily notes pages",
+    "author": "laixintao",
+    "tags": ["navigation", "daily notes", "calendar"],
+    "source_url": "https://github.com/laixintao/roam-research-history-of-today",
+    "source_repo": "https://github.com/laixintao/roam-research-history-of-today.git",
+    "source_commit": "db5b8e76db664654975d2929cd3c5ab9d4d2e6de"
+}

--- a/extensions/laixintao/roam-research-history-of-today.json
+++ b/extensions/laixintao/roam-research-history-of-today.json
@@ -5,5 +5,5 @@
     "tags": ["navigation", "daily notes", "calendar"],
     "source_url": "https://github.com/laixintao/roam-research-history-of-today",
     "source_repo": "https://github.com/laixintao/roam-research-history-of-today.git",
-    "source_commit": "db5b8e76db664654975d2929cd3c5ab9d4d2e6de"
+    "source_commit": "a6eb1dc0871a4484401c30200dde83ebd796373c"
 }


### PR DESCRIPTION
## Extension: History of Today

- **Source repo**: https://github.com/laixintao/roam-research-history-of-today
- **Author**: laixintao

### What it does

Adds **"On this day"** buttons at the bottom of the Roam calendar popover. When you open the date picker in the left sidebar, a row of small year buttons appears (e.g. `'25`, `'24`). Clicking one navigates to that year's daily notes page for the same date.

- Shows up to 5 previous years
- Only renders buttons for years that already have a daily notes page (queried via `roamAlphaAPI.q`)
- Hover tooltip shows the full date
- Cleans up on unload