### PR TITLE
Update toggle-uppercase.json

### DIFF
--- a/extensions/8bitgentleman/toggle-uppercase.json
+++ b/extensions/8bitgentleman/toggle-uppercase.json
@@ -5,6 +5,6 @@
     "tags": ["right-click menu", "formatting"],
     "source_url": "https://github.com/8bitgentleman/roam-depot-toggle-uppercase",
     "source_repo": "https://github.com/8bitgentleman/roam-depot-toggle-uppercase.git",
-    "source_commit": "deac7d4df02eeb2d20d6ce87325b6f1457ac5352",
+    "source_commit": "b9a26a98efb684f39d2c782064339cbbab2855e9",
     "stripe_account": "acct_1LJFEYQmxalymEZL"
   }


### PR DESCRIPTION
Avoid roam syntax when toggling
avoids ((block refs)), [[pages]], [aliases](), and {{components}}