### PR TITLE
Add Meta Type extension

### DIFF
--- a/extensions/wireframe/roam-meta-type.json
+++ b/extensions/wireframe/roam-meta-type.json
@@ -1,0 +1,9 @@
+{
+  "name": "Meta Type",
+  "short_description": "Typed pages with one chip per type and a sidebar panel for the fields you care about. Configurable via the settings panel.",
+  "author": "Ryan Sonnek",
+  "tags": ["metadata", "schema", "fields", "structure"],
+  "source_url": "https://github.com/wireframe/roam-meta-type",
+  "source_repo": "https://github.com/wireframe/roam-meta-type.git",
+  "source_commit": "332040f51e72c893d302698b427ff20ed510cd3f"
+}

--- a/extensions/wireframe/roam-meta-type.json
+++ b/extensions/wireframe/roam-meta-type.json
@@ -5,5 +5,5 @@
   "tags": ["metadata", "schema", "fields", "structure"],
   "source_url": "https://github.com/wireframe/roam-meta-type",
   "source_repo": "https://github.com/wireframe/roam-meta-type.git",
-  "source_commit": "332040f51e72c893d302698b427ff20ed510cd3f"
+  "source_commit": "1d2a64bef94868a16ef1a63ef4b0efa3808acda6"
 }


### PR DESCRIPTION
## Meta Type

Typed pages for Roam Research. Add a `Type::` block to a page and a chip appears next to the page title for each known type. Click a chip to open a sidebar panel with that type's pinned fields, rendered as label/value rows that double as inline editors via Roam's own block editor.

- **Source:** https://github.com/wireframe/roam-meta-type
- **README:** https://github.com/wireframe/roam-meta-type#readme
- **CHANGELOG:** https://github.com/wireframe/roam-meta-type/blob/main/CHANGELOG.md

## Notes

- Ships with no default types — users configure their own (name, HSL accent color, ordered field list) via the **Meta Type** tab in Roam settings, which renders a Blueprint-based editor.
- Fields are live: edits in the page body propagate to open panels via `roamAlphaAPI.data.addPullWatch`. Clicking a value cell flips it into Roam's embedded block editor (autocomplete, page-refs, formatting).
- React and BlueprintJS are consumed from the Roam-shipped `window.*` globals — verified by build-time externals plugin and a regression test (`test/build-externals.test.mjs`).
- Build runs via `build.sh` (`npm ci && npm run build`) on `ubuntu-24.04`. Output: `extension.js` (~28 KB) + `extension.css` (~5 KB) at the repo root.