### PR TITLE
Update Yesterday & Tomorrow

### DIFF
--- a/extensions/mlava/yesterday-tomorrow.json
+++ b/extensions/mlava/yesterday-tomorrow.json
@@ -5,6 +5,6 @@
   "tags": ["buttons", "navigation"],
   "source_url": "https://github.com/mlava/yesterday-tomorrow",
   "source_repo": "https://github.com/mlava/yesterday-tomorrow.git",
-  "source_commit": "7dbafc39db5a3233156fa63fe956fbe0a15dafce",
+  "source_commit": "559d55d3cc48cf32593bc517478dda6905d5a38c",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
Standardise DNP detection on Roam's data-page-uid attribute:
- Replace fragile URL-regex DNP detection with DOM-based lookup using Roam's data-page-uid attribute, and replace hand-rolled date formatting with roamAlphaAPI.util.dateToPageUid / dateToPageTitle. Smaller, safer, fixes one real bug along the way.

Bug fix: 
- createDiv's log-view branch had new Date(yyyy, mm, dd) where mm came from getMonth() + 1. The Date constructor expects a 0-based month, so on the log view all "yesterday/tomorrow" button labels were off by one calendar month. The collapsed call inherits resolveCurrentDate's correct logic.

-Collapse createDiv's 22-line duplicate date-derivation block into one await resolveCurrentDate(0) call.
- Replace formatDate + convertToRoamDate with dateToPageUid / dateToPageTitle; delete both helpers.