### PR TITLE
Update Todoist Task Management

### DIFF
--- a/extensions/mlava/todoist-task-management.json
+++ b/extensions/mlava/todoist-task-management.json
@@ -5,6 +5,6 @@
   "tags": ["tasks", "todoist", "todo"],
   "source_url": "https://github.com/mlava/todoist-task-management",
   "source_repo": "https://github.com/mlava/todoist-task-management.git",
-  "source_commit": "06cc64b3f82cc1fa977a8829007aa10453e85c21",
+  "source_commit": "b57e59e12cf9df1a6d4df43ce48e9cf66fbfa532",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
Standardise todoist-task-management on Roam's data-page-uid DOM attribute and roamAlphaAPI.util.dateToPage* helpers

Five spots in src/index.js were resolving "today's DNP UID" by checking window.location.href against a regex and constructing MM-DD-YYYY from new Date(). That pattern is fragile in two dimensions:

URL shape — breaks on self-hosted domains, encrypted graphs, query params, any future routing change. Local clock — uses the user's system time rather than what Roam is actually showing; can disagree near midnight or with clock drift.