### PR TITLE
Update Meta Type

### DIFF
--- a/extensions/wireframe/roam-meta-type.json
+++ b/extensions/wireframe/roam-meta-type.json
@@ -5,5 +5,5 @@
   "tags": ["metadata", "schema", "fields", "structure"],
   "source_url": "https://github.com/wireframe/roam-meta-type",
   "source_repo": "https://github.com/wireframe/roam-meta-type.git",
-  "source_commit": "1d2a64bef94868a16ef1a63ef4b0efa3808acda6"
+  "source_commit": "3abdf6934f3ca5743a4fa905a78371eceb4004d6"
 }


### PR DESCRIPTION
Bump `source_commit` for the Meta Type extension to `3abdf69`.

Changes since previous SHA:
- Use absolute image URLs in README so screenshots render in Roam Depot.