### PR TITLE
Add Oura Ring extension by MaskyS

### DIFF
--- a/extensions/maskys/oura-roam-research-plugin.json
+++ b/extensions/maskys/oura-roam-research-plugin.json
@@ -1,0 +1,9 @@
+{
+    "name": "Oura Ring",
+    "short_description": "Sync Oura Ring data into your graph as editable, queryable blocks with compact visual summaries.",
+    "author": "MaskyS",
+    "tags": ["health", "wellness", "wearables", "sleep", "activity", "biometrics", "hrv", "tracking", "import", "sync", "oura"],
+    "source_url": "https://github.com/MaskyS/oura-roam-research-plugin",
+    "source_repo": "https://github.com/MaskyS/oura-roam-research-plugin.git",
+    "source_commit": "cae12761942552c493465992345d2d9d0c7c3e49"
+}


### PR DESCRIPTION
## Summary
- Adds the Oura Ring extension manifest under `extensions/maskys/oura-roam-research-plugin.json`.
- The extension syncs Sleep, Readiness, Activity, Vitals, My Health, Workouts, and Tags from the Oura API into a configurable `[[Oura Ring]]` page as editable, queryable blocks, and renders compact visual summaries over those source blocks.

**Draft** — opened early to reserve the slot and gather feedback. I'm doing a final cleanup pass (CHANGELOG, README polish, dev-only `window.__ouraRoamExtension` global decision) and will mark ready for review with the corresponding `source_commit` bump.

## Repo
- Source: https://github.com/MaskyS/oura-roam-research-plugin
- Built artifacts (`extension.js`, `extension.css`) are committed at the repo root and also regenerated by `build.sh` (`npm run build`, no external dependencies).
- Tests: `npm run check` runs `node --test` over `plugin/oura-core.js` plus syntax checks on the bundle.

## Test plan
- [ ] Manifest validates against Roam Depot CI.
- [ ] `build.sh` runs cleanly under `ubuntu-24.04` and produces `extension.js` / `extension.css` at repo root.
- [ ] Extension loads in Roam Depot developer mode, registers settings panel, command palette entries (`Oura: Sync now`, `Oura: Backfill from date`, `Oura: Open Oura page`), and slash commands (`/oura today`, `/oura yesterday`, `/oura sleep`, `/oura callout`).
- [ ] Sync writes per-day blocks under `[[Oura Ring]]` and embeds the day's `Daily summary` block on existing Daily Notes only.