### PR TITLE
Fixes - Chief of Staff

### DIFF
--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "3af3abbcb71710fc8d9e9b9b38b53ea412aafa66",
+  "source_commit": "5e7266442450ea5d42d91ba0021c34d93346ba94",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
## Summary

- Fixes https://github.com/mlava/chief-of-staff/issues/85. Remote MCP `serverKey` (`"remote:" + normalizeRemoteMcpUrl(rawUrl)`) was written straight into the `mcp-schema-hashes` settings object. Roam Depot is Firebase-backed and rejects nested keys containing `. # $ / [ ]` — every remote MCP server tripped this on `/` and `.`. Surfaced as the "Roam MCP error" toast and silently disabled supply-chain schema pinning for every remote server.
- Same root cause as the existing `sanitiseKey()` in `usage-tracking.js` (shipped for `gpt-5.4-mini`-style model IDs); patch never reached the schema-pin path.
- Sanitisation (`. # $ / [ ]` → `_`) chosen over the reporter's base64 suggestion to match the in-tree pattern and keep stored keys readable.

## Changes

- `src/security-core.js` — export `sanitiseRoamSettingsKey()`; apply it inside `checkSchemaPinCore` to `serverKey` and to the tool-name keys in `newToolFingerprints` (legacy Composio dotted slugs like `gmail.fetch_emails` would also trip the constraint).
- `src/local-mcp.js` — same canonicalisation in `unsuspendMcpServer`'s accept-new-pin write path. In-memory `suspendedMcpServers` Map keeps the raw key; sanitisation only at the settings.set boundary.
- `tests/security-core.test.mjs` — two regression tests: the helper directly, and a full pin → round-trip with a URL-style `serverKey` plus a dotted tool name, asserting no stored key contains a forbidden char and that the second call resolves to `unchanged` (read/write canonicalisation agree).

## Migration

Existing remote-MCP pin entries (if any wrote successfully through some other path) become invisible on next connect and get re-pinned once. Schema pins are derived state — no data loss.

---

## Summary

Closes https://github.com/mlava/chief-of-staff/issues/88. A bad custom-LLM endpoint config caused the inbox processor to flood the UI with retry toasts that blocked half the screen. Root cause was two unrelated bugs amplifying each other, plus a recovery dead-end where uninstall/reinstall didn't clear Roam Depot's IndexedDB-backed settings.

## Root cause

- **Description block re-processed on every scan.** The startup static-UID snapshot in `src/index.js` only matches a hardcoded list of *legacy* instructional texts — none of which match the current `ℹ️ Input queue — …` pinned description block. The description block slipped through, got queued for the agent loop on every pull-watch tick, and failed every time on a broken LLM config.
- **No failed-state tracking.** `processInboxItem`'s catch block showed an error toast but never recorded the UID anywhere. Persistent failures (bad LLM config, expired key) were re-queued on the next pull-watch tick. The "Processing: …" start toast doubled the per-item toast volume.
- **No recovery hatch.** Roam Depot persists `extensionAPI.settings` to IndexedDB across uninstall/reinstall, so users with poisoned configs had no clean way out.

## Changes

**`src/inbox.js`**
- New `inboxFailedUIDs` Set populated in the catch block (non-deleted failure path) and checked in `getInboxCandidateBlocksFromChildrenRows`. Cleared on `cleanupInbox` so reload re-enables retry.
- New `descriptionPrefix` dep injected via `initInbox`. Candidate filter skips any block whose trimmed string starts with the prefix — content-based, robust across page age and recreation.
- Removed the per-item "Processing: …" start toast. Terminal "Done"/"Failed" toast remains.
- Exported `resetInboxFailedUIDs` / `getInboxFailedUIDs` for tests and as a hook for a future "Retry inbox failures" command.

**`src/index.js`**
- `initInbox` call now passes `descriptionPrefix: PAGE_DESCRIPTION_PREFIX`.
- New helper `clearAllExtensionSettings(extensionAPI)` uses `extensionAPI.settings.getAll()` to enumerate every key (including dynamic numbered slots like `custom-llm-2-api-key`, `remote-mcp-3-url` not listed in `SETTINGS_KEYS`) and clears each via `set(key, undefined)`.
- New command **Chief of Staff: Reset All Settings (Recovery)** with `iziToast.show` centered overlay confirmation (red "Reset everything" / "Cancel" buttons), modelled on the existing MCP-schema-change toast pattern. Tells the user to reload Roam after confirming.

**`README.md`**
- New row in the command palette table for the recovery command.
- New "Recovery — starting over" subsection at the end of Setup explaining the IndexedDB persistence trap, what the command does, what it leaves alone, and when to prefer targeted commands instead.