### PR TITLE
Add Alias Finder extension

### DIFF
--- a/extensions/wireframe/roam-alias-finder.json
+++ b/extensions/wireframe/roam-alias-finder.json
@@ -1,0 +1,9 @@
+{
+  "name": "Alias Finder",
+  "short_description": "Find unlinked plain-text mentions of a page's existing aliases and link them in one click.",
+  "author": "Ryan Sonnek",
+  "tags": ["aliases", "links", "references", "linking", "writing"],
+  "source_url": "https://github.com/wireframe/roam-alias-finder",
+  "source_repo": "https://github.com/wireframe/roam-alias-finder.git",
+  "source_commit": "725b254fbd7ffcec16638a6c9c2651d33dc131ca"
+}

--- a/extensions/wireframe/roam-alias-finder.json
+++ b/extensions/wireframe/roam-alias-finder.json
@@ -5,5 +5,5 @@
   "tags": ["aliases", "links", "references", "linking", "writing"],
   "source_url": "https://github.com/wireframe/roam-alias-finder",
   "source_repo": "https://github.com/wireframe/roam-alias-finder.git",
-  "source_commit": "725b254fbd7ffcec16638a6c9c2651d33dc131ca"
+  "source_commit": "f61f466aaa3d0c8c24b71e2bc8609b5057744a7b"
 }


### PR DESCRIPTION
Submitting **Alias Finder**, a free extension.

It adds a "Find unlinked aliases" button below a page's references that scans the graph for plain-text mentions of the page's existing aliases and links each one in a click (wrapping it as `[text]([[Page]])`, preserving casing). Matching is whole-word and case-insensitive, and skips text already inside page links, block refs, tags, URLs, and markdown link labels. Daily-note pages are excluded.

- Repo: https://github.com/wireframe/roam-alias-finder
- Builds via `build.sh` (esbuild bundles `src/` into `extension.js`); `extension.css` is committed.
- Manifest: `extensions/wireframe/roam-alias-finder.json`