### PR TITLE
Update Chief of Staff

### DIFF
--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "5e7266442450ea5d42d91ba0021c34d93346ba94",
+  "source_commit": "c766a3dd1bf604f67f4c9847b8754cef33bb1750",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
Refresh LLM tiers + add model-availability check, settings-panel & test fixes

Updated the default model IDs in src/aibom-config.js (the runtime source of truth for tier defaults):

New: LLM Model Availability check
getConfiguredLlmModelTargets, classifyModelSmokeError, and the smoke-test runner in src/llm-providers.js send a tiny prompt to each configured provider/tier model ID and classify failures (auth / rate-limit / invalid-model / transient).

Wired to Chief of Staff: Check LLM Model Availability command palette entry and surfaced as a Run check button on the settings row.

Settings-panel fix — silence extension setting action not found Roam logs that warning (once per render pass) for any settings item without an action. Converted the two display-only rows in src/settings-config.js to real buttons:

"LLM Model Availability" → Run check (triggers the smoke test directly) "No extensions detected" → Refresh (rebuilds the panel to re-scan ext tools)

Other
New tests in tests/llm-providers.test.mjs covering smoke-test target enumeration and error classification. Dependency bumps: @modelcontextprotocol/sdk 1.26.0 → 1.29.0, webpack 5.105.1 → 5.107.2; npm test now runs with --experimental-default-type=module. README tier table, command palette, and Opus version references updated to match.