### PR TITLE
Alias Finder: update source_commit

### DIFF
--- a/extensions/wireframe/roam-alias-finder.json
+++ b/extensions/wireframe/roam-alias-finder.json
@@ -5,5 +5,5 @@
   "tags": ["aliases", "links", "references", "linking", "writing"],
   "source_url": "https://github.com/wireframe/roam-alias-finder",
   "source_repo": "https://github.com/wireframe/roam-alias-finder.git",
-  "source_commit": "f61f466aaa3d0c8c24b71e2bc8609b5057744a7b"
+  "source_commit": "509f63f8711898355defcd8ea53cd5cb16381dda"
 }


### PR DESCRIPTION
Updates Alias Finder to commit `509f63f`.

**Fix:** the "Find unlinked aliases" button no longer appears when a block is zoomed into the main view. Page-vs-block is now detected by the open route UID (a page's UID has `:node/title`, a zoomed block's does not) instead of matching rendered title text — which misfired when a block's text referenced a real page.