### PR TITLE
Add RoamJS Pinned Blocks extension

### DIFF
--- a/extensions/RoamJS/pinned-blocks.json
+++ b/extensions/RoamJS/pinned-blocks.json
@@ -13,6 +13,6 @@
   ],
   "source_url": "https://github.com/RoamJS/pinned-blocks",
   "source_repo": "https://github.com/RoamJS/pinned-blocks.git",
-  "source_commit": "d213b6a3687bc4c654556c01b4357980c2344229",
+  "source_commit": "a2c809e350992a940a5889d230721480a460049a",
   "stripe_account": "acct_1SvNcDHhjqZussBl"
 }

--- a/extensions/RoamJS/pinned-blocks.json
+++ b/extensions/RoamJS/pinned-blocks.json
@@ -13,6 +13,6 @@
   ],
   "source_url": "https://github.com/RoamJS/pinned-blocks",
   "source_repo": "https://github.com/RoamJS/pinned-blocks.git",
-  "source_commit": "a2c809e350992a940a5889d230721480a460049a",
+  "source_commit": "027b9365378309be8be81724a36e45b26418461b",
   "stripe_account": "acct_1SvNcDHhjqZussBl"
 }

--- a/extensions/RoamJS/pinned-blocks.json
+++ b/extensions/RoamJS/pinned-blocks.json
@@ -1,0 +1,18 @@
+{
+  "name": "Pinned Blocks",
+  "short_description": "Keep important child blocks fixed at the top of their parent, even as new siblings are added above them.",
+  "author": "RoamJS",
+  "tags": [
+    "pinned blocks",
+    "pin",
+    "blocks",
+    "outline",
+    "organization",
+    "navigation",
+    "workflow"
+  ],
+  "source_url": "https://github.com/RoamJS/pinned-blocks",
+  "source_repo": "https://github.com/RoamJS/pinned-blocks.git",
+  "source_commit": "d213b6a3687bc4c654556c01b4357980c2344229",
+  "stripe_account": "acct_1SvNcDHhjqZussBl"
+}

--- a/extensions/RoamJS/pinned-blocks.json
+++ b/extensions/RoamJS/pinned-blocks.json
@@ -13,6 +13,6 @@
   ],
   "source_url": "https://github.com/RoamJS/pinned-blocks",
   "source_repo": "https://github.com/RoamJS/pinned-blocks.git",
-  "source_commit": "027b9365378309be8be81724a36e45b26418461b",
+  "source_commit": "2540440015b0bb8bba1778e86d16f82630eb9685",
   "stripe_account": "acct_1SvNcDHhjqZussBl"
 }

--- a/extensions/RoamJS/pinned-blocks.json
+++ b/extensions/RoamJS/pinned-blocks.json
@@ -13,6 +13,6 @@
   ],
   "source_url": "https://github.com/RoamJS/pinned-blocks",
   "source_repo": "https://github.com/RoamJS/pinned-blocks.git",
-  "source_commit": "2540440015b0bb8bba1778e86d16f82630eb9685",
+  "source_commit": "acebfc803ee078bddbf03dd6b1db61fea6f2959a",
   "stripe_account": "acct_1SvNcDHhjqZussBl"
 }


### PR DESCRIPTION
## Summary

Adds RoamJS Pinned Blocks to Roam Depot with metadata under `extensions/RoamJS/pinned-blocks.json`.

## Details

The descriptor points to `https://github.com/RoamJS/pinned-blocks` at commit `2540440015b0bb8bba1778e86d16f82630eb9685`, includes RoamJS as the author, and uses the same RoamJS Stripe account as the other RoamJS Depot entries.

## Validation

- `jq empty extensions/RoamJS/pinned-blocks.json`
- `git diff --check HEAD~1..HEAD`
- `git diff --check`
- Depot-style source verification: cloned `RoamJS/pinned-blocks`, checked out `2540440015b0bb8bba1778e86d16f82630eb9685`, ran `sh build.sh`, and confirmed `samepage build --dry` completed with `src built with 0 errors`.

