### PR TITLE
Add Related Notes extension

### DIFF
--- a/extensions/qcrao/roam-related-notes.json
+++ b/extensions/qcrao/roam-related-notes.json
@@ -1,9 +1,14 @@
 {
   "name": "Related Notes",
-  "short_description": "Find notes you forgot you wrote. Semantic search and automatic related-note discovery, powered by Roam's native semantic engine.",
+  "short_description": "Find notes you forgot you wrote. As you browse, a panel automatically surfaces semantically related pages and blocks, powered by Roam's native semantic engine.",
   "author": "qcrao",
-  "tags": ["search", "ai", "navigation", "productivity"],
+  "tags": [
+    "search",
+    "ai",
+    "navigation",
+    "productivity"
+  ],
   "source_url": "https://github.com/qcrao/roam-related-notes",
   "source_repo": "https://github.com/qcrao/roam-related-notes.git",
-  "source_commit": "20e83b2a446056c088846454fa9a5b347ebfa1ec"
+  "source_commit": "07bf1771fcd374f2459ee90a0ca3a4f6ebd8a5ea"
 }

--- a/extensions/qcrao/roam-related-notes.json
+++ b/extensions/qcrao/roam-related-notes.json
@@ -1,0 +1,9 @@
+{
+  "name": "Related Notes",
+  "short_description": "Find notes you forgot you wrote. Semantic search and automatic related-note discovery, powered by Roam's native semantic engine.",
+  "author": "qcrao",
+  "tags": ["search", "ai", "navigation", "productivity"],
+  "source_url": "https://github.com/qcrao/roam-related-notes",
+  "source_repo": "https://github.com/qcrao/roam-related-notes.git",
+  "source_commit": "20e83b2a446056c088846454fa9a5b347ebfa1ec"
+}


### PR DESCRIPTION
## Related Notes

Semantic search and automatic related-note discovery, powered by Roam's native semantic engine (`semanticSearch` API).

- **Related Notes panel**: as you browse, a draggable/resizable panel automatically surfaces semantically similar pages and blocks — grouped by chunk with per-page diversity, so one long note never floods the list
- **Semantic search** (`Ctrl+Shift+S`): search the graph by meaning, keyboard-first; works cross-lingual (e.g. a Chinese query finds English notes)
- **Graceful fallback**: if the graph's semantic embeddings are off, everything still works via literal matching, with a hint on how to enable the engine
- **Strictly read-only, zero external requests, no telemetry**: the extension only calls Roam's built-in APIs; embedding routing is entirely controlled by the user's own Roam settings

Repo: https://github.com/qcrao/roam-related-notes (README includes a detailed privacy section and a technical deep-dive doc)

Author: qcrao (existing Depot extensions: Roam Copilot, Last Year Today, Card Theme, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZheN6BbWr4zmE8jLiSSpg