### PR TITLE
Add Roam Atlas extension

### DIFF
--- a/extensions/wireframe/roam-atlas.json
+++ b/extensions/wireframe/roam-atlas.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roam Atlas",
+  "short_description": "Pin pages and blocks with a Location:: attribute on an interactive map — geocoded automatically and cached in your graph.",
+  "author": "Ryan Sonnek",
+  "tags": ["maps", "geolocation"],
+  "source_url": "https://github.com/wireframe/roam-atlas",
+  "source_repo": "https://github.com/wireframe/roam-atlas.git",
+  "source_commit": "f034ca515c0a4f3778a95acf3f5a24f039d6e307"
+}


### PR DESCRIPTION
Adds **Roam Atlas** — map your located Roam pages and blocks on an interactive map.

Give any page or block a `Location::` attribute, reference it under a `{{[[atlas]]}}` block, and Atlas geocodes it via Nominatim, caches the coordinates back into the graph as a `Coordinates::` attribute, and pins it. Tiles are OpenStreetMap (via CARTO); no account or API key required.

Source: https://github.com/wireframe/roam-atlas