### PR TITLE
Update Chief of Staff

### DIFF
--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "d20adf7f0b1fe477608130791cfb997f07b1ca36",
+  "source_commit": "966740484f8cae6e97383c54d07fccd7195cf39b",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "b3a02ebccea0bda64f53a9b392a994d19000f31f",
+  "source_commit": "89ee7aa56282e565024ba473b4fc29afd60c0843",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "c766a3dd1bf604f67f4c9847b8754cef33bb1750",
+  "source_commit": "f307f93736ec7cbb8663fd0d15e5549fcb35d56d",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "aca33f82ec8996e73e7e219fcb7ab8af50b2e484",
+  "source_commit": "8d9b4c8516026882b509a45a9618bc6327450f4b",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "8d9b4c8516026882b509a45a9618bc6327450f4b",
+  "source_commit": "d20adf7f0b1fe477608130791cfb997f07b1ca36",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "89ee7aa56282e565024ba473b4fc29afd60c0843",
+  "source_commit": "d45833ed2439fe393e11199f31ce19098574070d",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "f307f93736ec7cbb8663fd0d15e5549fcb35d56d",
+  "source_commit": "aca33f82ec8996e73e7e219fcb7ab8af50b2e484",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "afc912942e65a07994116b916e59e321e9c6664d",
+  "source_commit": "c18bd6106dc4f7f79bb67b9702587c8cec0d5604",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "d45833ed2439fe393e11199f31ce19098574070d",
+  "source_commit": "afc912942e65a07994116b916e59e321e9c6664d",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "966740484f8cae6e97383c54d07fccd7195cf39b",
+  "source_commit": "b3a02ebccea0bda64f53a9b392a994d19000f31f",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "c18bd6106dc4f7f79bb67b9702587c8cec0d5604",
+  "source_commit": "a8f305bff2bc1dbc5bf4c8b635dd4f9c47083824",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
### Chat commands: plan-first execution, batch undo, and transparency tools

This update (12 commits, ~3,300 lines added across 25 files, test suite now at 845) turns the chat panel into a proper command surface, built around one idea: **you should be able to preview what the assistant will do, reverse what it did, and inspect how it did it.**

**Before acting — `/plan`**
Prefix any request with `/plan` and the assistant explores the graph read-only, then presents numbered steps, the tools it will call, and every page/block it intends to write. Nothing executes until the user clicks **Run plan** (or types `go`); **Discard** throws it away. The plan pass can *see* write tools but cannot *execute* them — enforcement happens at the tool-execution gate, not via prompt instructions. Normal per-tool approval gating still applies to the execute pass; plan approval adds consent, it never bypasses it.

**After acting — `/undo`**
A new COS-scoped mutation ledger records every block the assistant creates (and before-images of every block it edits) during a user-initiated run. `/undo` — or saying "undo" / "oops" — shows exactly what will be reversed, waits for confirmation, then deletes created blocks in reverse order and restores edited blocks to their previous content. Safety properties:

- Blocks the user has edited since are detected via after-image comparison and left alone.
- Pages are deleted only if empty.
- Deletes/moves and external actions (e.g. sent emails) are declined and named honestly rather than faked.
- The user's own edits are never touched.
- Only user-initiated chat runs are ledgered — cron/inbox runs can't claim or clobber the undo slot.

⚠️ *Behaviour change:* the old `roam_undo` was a raw global `data.undo()` — it popped whatever was on top of Roam's shared undo stack, which could be the **user's** latest edit, and could only reverse one operation. That surface is gone (`roam_redo` retired with it). Roam's native Ctrl/Cmd+Z is unaffected and remains the path for the user's own edits.

**Understanding what happened — `/why`, `/status`, `/verify`**

- `/why` explains the last response: model, tier and *why* that tier (explicit flag, auto-escalation with the recorded reason, or default), tool calls with durations, any self-correction guards that fired, and estimated input tokens. Instant pattern-matched answers say so plainly: no model call, no tokens, nothing left the browser.
- `/status` is a read-only, zero-network snapshot of everything running autonomously: connections, scheduled jobs with last-run results, background idle tasks, pending plan approvals, undoable changes, and session cost.
- `/verify` scores the last response with an independent judge model on demand (task completion / factual grounding / safety plus binary checks), even when background evaluation is off. Low scores are filed to the Review Queue.

**Workflow & discoverability**

- Typing `/` opens an autocomplete menu of all commands, backed by a shared registry that also drives `/help` — the two can't drift. The menu also fires mid-message on a trailing `/token`, offering just the inline flags (`/power`, `/plan`, provider overrides) and completing in place; URLs and paths never trigger it.
- Mistyped lone commands (`/veridy`) get an instant "did you mean `/verify`?" instead of an LLM call.
- `/export` writes the chat transcript to today's daily page under a `[[Chief of Staff/Transcripts]]` header (optional `/tag Name` to tag it); `/new` added as a synonym for `/clear`.
- Bundled robustness fixes: a new `roam_create_page` tool, and write tools now accept a page title or `[[Page]]` ref as the parent (creating the page if missing) — the failure mode where models pass a title where a UID is expected is now handled instead of erroring.

**Safety posture**
No changes to approval gating, injection defences, or the read-only inbox contract. All mutations remain approval-gated; all new commands are UI-side and read-only except the `/verify` judge call (one cheap mini-tier request).
