### PR TITLE
Update Better Tasks

### DIFF
--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "03b82d419b49f4cea415377f9279992d88fb0199",
+  "source_commit": "86f337cd4a74115d2ceaffb51ade66e798a988d4",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "86f337cd4a74115d2ceaffb51ade66e798a988d4",
+  "source_commit": "5c7bd33c1d3730b169b3fcba2a14fc10a30c56ce",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "f302ca34dfcda32664303df47ae4deb034f79076",
+  "source_commit": "03b82d419b49f4cea415377f9279992d88fb0199",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
## Better Tasks — bug-fix release

No new features, no new settings, no schema changes. Ten correctness fixes across four
subsystems, plus a unit-test suite to stop them recurring.

### User-facing fixes

**Recurring task scheduling (4 bugs).**
- `on the 1st and 15th of each month` (and any multi-day rule including the 1st) skipped
  the 1st whenever the schedule crossed a month boundary.
- `every month on the second tuesday` and `every 3 months on the 2nd tuesday` were parsed
  as a plain weekly Tuesday, ignoring the monthly interval.
- `every other tuesday` scheduled weekly rather than fortnightly.
- `first monday of september` failed to parse unless `every year` was appended.

**Circular dependency detection (3 bugs).** The cycle check's `maxDepth = 20` guard actually
counted *nodes expanded*, not depth, so a dependency chain longer than ~21 links slipped
through. Both the write guard and the picker then permitted closing a ring, in which every
task stayed blocked forever waiting on the next. Additionally, a search that ran out of
budget cached its inconclusive "no cycle" answer permanently, and cached verdicts were not
invalidated when a task in the *middle* of a chain changed.

**ICS calendar export (3 bugs).** `SUMMARY` and `CATEGORIES` wrote TEXT values unescaped —
RFC 5545 §3.3.11 requires escaping `\ ; ,` and newlines, so an ordinary title like
`Buy milk, eggs` produced a malformed property. `DTSTAMP` (required in every `VEVENT` by
§3.6.1) was absent entirely, and content lines were not folded at 75 octets (§3.1). Two
line-for-line duplicate ICS builders were collapsed into one. CSV export now also quotes
values containing a bare carriage return.

**Localisation.** Two strings were still English in `zh` and `zhHant`.

### Notes for review

- **No new MutationObservers.** The diff adds zero (`git diff | grep '^+.*new MutationObserver'`
  → 0). The existing completion observer had redundant work removed: Roam emits several
  nested `childList` records for one logical block change, and the handler was deriving the
  block uid once per record. It now dedupes per uid per batch, which also fixes a stale
  entry that `noteDoneAddition` re-inserted into the completion-pairing map after each
  completion.
- **No new `roamAlphaAPI` surface, no new network requests, no external CDN loads.**
- **No new runtime dependencies.** `package.json` gains only npm scripts; tests use Node's
  built-in `node --test`.
- **No schema migration.** `BT_attr*` child blocks are read and written exactly as before,
  and the deconvert (clean-exit) path is unchanged.
- **No new destructive writes** — the diff adds no `block.delete` or `page.delete` calls.

### One behaviour change worth flagging

`bt_modify` (Extension Tools API) and the dependency picker now **reject** dependency edges
they previously accepted, in graphs whose dependency subgraph exceeds ~21 nodes. Those edges
genuinely closed a cycle; accepting them is what caused the permanent-blocked state. Users
with existing rings will see those tasks become actionable again, since the blocked-state
calculation can now detect the cycle and skip it.