### PR TITLE
similar-pages modernization

### DIFF
--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -5,6 +5,6 @@
   "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
   "source_url": "https://github.com/8bitgentleman/roam-depot-similar-pages",
   "source_repo": "https://github.com/8bitgentleman/roam-depot-similar-pages.git",
-  "source_commit": "67f3e6b608bceb9e758b4790d544ae2394edbdf9",
+  "source_commit": "98171a71db25aa27eb9c9f0a5ab6fbf0e768afbe",
   "stripe_account": "acct_1LJFEYQmxalymEZL"
 }

--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -1,10 +1,10 @@
 {
   "name": "Similar Pages",
   "short_description": "uses machine learning and graph theory to help you find connections between ideas",
-  "author": "scott block",
+  "author": "scott block & Matt Vogel",
   "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
-  "source_url": "https://github.com/phonetonote/similar-pages",
-  "source_repo": "https://github.com/phonetonote/similar-pages",
-  "source_commit": "3ff405740863f73621cc0c7bccaee5909d2e685e",
-  "stripe_account": "acct_1LKwanQVF0QOKIg5"
+  "source_url": "https://github.com/8bitgentleman/roam-depot-similar-pages",
+  "source_repo": "https://github.com/8bitgentleman/roam-depot-similar-pages.git",
+  "source_commit": "dd85d3962f845a4528a23fb90e6bca3f02bd2be5",
+  "stripe_account": "acct_1LJFEYQmxalymEZL"
 }

--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -5,6 +5,6 @@
   "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
   "source_url": "https://github.com/8bitgentleman/roam-depot-similar-pages",
   "source_repo": "https://github.com/8bitgentleman/roam-depot-similar-pages.git",
-  "source_commit": "34a7d9997135fa7446c92811191f0c2537f868e8",
+  "source_commit": "67f3e6b608bceb9e758b4790d544ae2394edbdf9",
   "stripe_account": "acct_1LJFEYQmxalymEZL"
 }

--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -5,6 +5,6 @@
   "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
   "source_url": "https://github.com/8bitgentleman/roam-depot-similar-pages",
   "source_repo": "https://github.com/8bitgentleman/roam-depot-similar-pages.git",
-  "source_commit": "98171a71db25aa27eb9c9f0a5ab6fbf0e768afbe",
+  "source_commit": "efa27f9b2dc436893045fb9f7861be4fe3f8ff53",
   "stripe_account": "acct_1LJFEYQmxalymEZL"
 }

--- a/extensions/phonetonote/similar-pages.json
+++ b/extensions/phonetonote/similar-pages.json
@@ -5,6 +5,6 @@
   "tags": ["machine learning", "natural language processing", "nlp", "graph theory", "universal sentence encoder"],
   "source_url": "https://github.com/8bitgentleman/roam-depot-similar-pages",
   "source_repo": "https://github.com/8bitgentleman/roam-depot-similar-pages.git",
-  "source_commit": "dd85d3962f845a4528a23fb90e6bca3f02bd2be5",
+  "source_commit": "34a7d9997135fa7446c92811191f0c2537f868e8",
   "stripe_account": "acct_1LJFEYQmxalymEZL"
 }


### PR DESCRIPTION


The original similar-pages extension leaned on an old embedding stack and a scoring formula that fought itself. On a real graph it surfaced weak, noisy matches. This modernizes the semantic core and fixes races that could leave the panel stuck or showing stale results.

The changes fall into two buckets: **(1) a modernized similarity engine** and **(2) correctness hardening** around the async embedding pipeline.

1. Modernized similarity engine (three changes, each isolated + measured on a ~2,300-page graph):
- Model: USE → BGE-small-en-v1.5 - top-10 avg cosine 0.38 → 0.71. Still fully local via transformers.js.
- Content window: 250 → 2000 chars - old cap embedded ~title + first block; new window embeds what the page is actually about.
- Scoring: distance × similarity → similarity + 0.1 × distance - old formula structurally hid your most-similar pages (multiplying by distance zeroed out close matches); new one ranks by similarity with a small bonus for far-but-similar "discoveries."

2. Correctness hardening - partial-embedding race (generation guard), duplicate IndexedDB connection (shared ref), silent worker failures (error card instead of infinite spinner), dtype: "q8" API update.

(Permission was given by the original author for this fork)