### PR TITLE
Update Chief of Staff

### DIFF
--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "a8f305bff2bc1dbc5bf4c8b635dd4f9c47083824",
+  "source_commit": "b48859b864fb471e20d45822ec617e6395c5e518",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
OpenAI power/ludicrous → gpt-5.6-terra / gpt-5.6-sol

Org rollout landed overnight (GA Jul 9 provisioned org-by-org). All provider/tier combos re-verified green via availability check. Completes the lineup refresh; interim gpt-5.4/5.5 no longer needed.