### PR TITLE
Update Better Tasks — Task Deletion and Roam query integration

### DIFF
--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "5c7bd33c1d3730b169b3fcba2a14fc10a30c56ce",
+  "source_commit": "2cd7da34a52eb5d426a74d39c3b7bdadb566641a",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "2cd7da34a52eb5d426a74d39c3b7bdadb566641a",
+  "source_commit": "971376b56474b0ec20c591ed629cc7d1a02f2ac0",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -1,6 +1,6 @@
 {
   "name": "Better Tasks",
-  "short_description": "Recurring and scheduled TODOs for Roam — repeat rules, due dates, inline controls and a review dashboard. Stored as plain Roam blocks, reversible any time.",
+  "short_description": "Recurring and scheduled TODOs for Roam - repeat rules, due dates, inline controls and a review dashboard. Stored as plain Roam blocks, reversible any time.",
   "author": "Mark Lavercombe",
   "tags": ["todo", "tasks", "recurring", "recurring tasks", "due dates", "scheduling", "deadlines", "reminders", "dashboard", "subtasks", "projects", "gtd", "getting things done", "weekly review", "productivity"],
   "source_url": "https://github.com/mlava/better-tasks",

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -1,6 +1,6 @@
 {
   "name": "Better Tasks",
-  "short_description": "Implement comprehensive task management within Roam Research, including dated and recurring tasks, and other optional attributes like GTD tags, projects and more.",
+  "short_description": "Recurring and scheduled TODOs for Roam — repeat rules, due dates, inline controls and a review dashboard. Stored as plain Roam blocks, reversible any time.",
   "author": "Mark Lavercombe",
   "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
   "source_url": "https://github.com/mlava/better-tasks",

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -2,7 +2,7 @@
   "name": "Better Tasks",
   "short_description": "Recurring and scheduled TODOs for Roam — repeat rules, due dates, inline controls and a review dashboard. Stored as plain Roam blocks, reversible any time.",
   "author": "Mark Lavercombe",
-  "tags": ["recurring", "recurrent", "TODO", "tasks", "DONE", "getting things done", "gtd", "review"],
+  "tags": ["todo", "tasks", "recurring", "recurring tasks", "due dates", "scheduling", "deadlines", "reminders", "dashboard", "subtasks", "projects", "gtd", "getting things done", "weekly review", "productivity"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
   "source_commit": "971376b56474b0ec20c591ed629cc7d1a02f2ac0",

--- a/extensions/mlava/recurring-tasks.json
+++ b/extensions/mlava/recurring-tasks.json
@@ -5,6 +5,6 @@
   "tags": ["todo", "tasks", "recurring", "recurring tasks", "due dates", "scheduling", "deadlines", "reminders", "dashboard", "subtasks", "projects", "gtd", "getting things done", "weekly review", "productivity"],
   "source_url": "https://github.com/mlava/better-tasks",
   "source_repo": "https://github.com/mlava/better-tasks.git",
-  "source_commit": "971376b56474b0ec20c591ed629cc7d1a02f2ac0",
+  "source_commit": "416f5d4749b559da1984040041a12519ef552131",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
## What's new

**Task Deletion** — tasks can now be deleted (with their whole subtree: metadata child blocks, nested subtasks, notes, activity history) directly from the dashboard row menu, the inline pill menu, the bulk-action bar, a keyboard shortcut (`d`, customisable), or the Extension Tools API (`bt_delete` / `bt_bulk_delete`, registry v1.3).

Safety model, consistent with the extension's no-destructive-writes principle:

- Every delete is confirmed first (with a subtask-count warning when relevant); programmatic deletes require an explicit `confirm: true` argument.
- An Undo toast restores the task exactly as it was — original block uids, metadata, subtask nesting, activity history, recurring-series props, and the dependency references of other tasks that pointed at it.
- References managed by the extension (dependencies, explicit subtask links) are cleaned *before* the block is deleted, so Roam never flattens them into orphaned text; they are re-added on undo.

## Fixes

- **Localisation:** bulk-action bar labels and twelve dashboard menu items (Add/Edit/Remove × repeat/start/defer/due) always rendered in English due to missing keys/wiring — now translated in all 13 supported locales, along with all new deletion strings (reviewed per-locale).
- **Lifecycle:** `onunload` now disconnects the main MutationObserver and removes all extension-rendered pill elements — previously a superseded instance could keep serving UI after an extension update until a full page reload.
- **Activity log:** dependency-change events now record task titles as plain text instead of live `((block refs))`, so history stays readable if a referenced task is later deleted.
- **API:** `bt_bulk_modify` / `bt_bulk_snooze` no longer return a spurious `refresh is not defined` error after succeeding.
- Dashboard keyboard shortcuts are inert while a confirmation dialog is open; cancelling a bulk delete keeps the selection.


No new dependencies. No settings schema changes. All writes remain reversible.