### PR TITLE
Update Better Bullets

### DIFF
--- a/extensions/mlava/better-bullets.json
+++ b/extensions/mlava/better-bullets.json
@@ -5,6 +5,6 @@
   "tags": ["bullet", "semantic"],
   "source_url": "https://github.com/mlava/better-bullets",
   "source_repo": "https://github.com/mlava/better-bullets.git",
-  "source_commit": "3d1d856236388be8ad6c83e09b5c92f0b70acd1f",
+  "source_commit": "1d1abdc4aa2039ec2e7e7d3b815f0f2991b4af78",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
### What's new
Better Bullets replaces Roam's default bullet dot with glyph bullets triggered by prefix markers (-> , => , ?? …). This update adds a second, independent marker dimension: provenance — where a block's content came from, as opposed to what kind of reasoning it is.

Six provenance types (calendar, email, phone, chat, scanned post, Slack), each persisted to its own block prop (better-bullets/provenance) and rendered as a small badge alongside the existing bullet. The two dimensions compose: 📨 -> chase the contract is an email-sourced "leads to" bullet, carrying both a badge and a bullet glyph.

Provenance can be applied either by typing a prefix, or — preferably — via a Mark as … command per enabled type, registered through extensionAPI.ui.commandPalette so it groups under the extension in the Hotkeys window. Every prefix is user-configurable.

### Backwards compatibility
Existing users see no change on upgrade. All six provenance types ship disabled by default, and the entire provenance settings section is hidden behind a Show provenance settings toggle that also defaults off. Existing bullet types, prefixes, stripping behaviour and persisted better-bullets/type props are untouched.

### Data safety
This update fixes a pre-existing data-safety bug rather than introducing risk. roamAlphaAPI.updateBlock replaces :block/props wholesale, and the extension previously wrote props: { "better-bullets/type": … } directly — which silently destroyed props written by other extensions on the same block. Prop writes are now read-modify-write and serialised per block (two writes to one block in the same tick could otherwise race and drop each other's key).

No destructive text edits: marker stripping remains opt-in and off by default, and never runs while a block is focused.

### Permissions / network
None. No new external requests; the extension runs entirely client-side against roamAlphaAPI and extensionAPI, as before.