### PR TITLE
Update Alias Finder (bug fix: button now appears on pages)

### DIFF
--- a/extensions/wireframe/roam-alias-finder.json
+++ b/extensions/wireframe/roam-alias-finder.json
@@ -5,5 +5,5 @@
   "tags": ["aliases", "links", "references", "linking", "writing"],
   "source_url": "https://github.com/wireframe/roam-alias-finder",
   "source_repo": "https://github.com/wireframe/roam-alias-finder.git",
-  "source_commit": "509f63f8711898355defcd8ea53cd5cb16381dda"
+  "source_commit": "bbebd7209d3aa0d8bcc62cf68c188f2b3bca89f4"
 }


### PR DESCRIPTION
Updates **Alias Finder** by bumping `source_commit`.

- Extension repo: https://github.com/wireframe/roam-alias-finder
- Old commit: `509f63f8711898355defcd8ea53cd5cb16381dda`
- New commit: `bbebd7209d3aa0d8bcc62cf68c188f2b3bca89f4`

### What changed
Fixes a regression where the **Find unlinked aliases** button failed to appear on any page. `roamAlphaAPI.ui.mainWindow.getOpenPageOrBlockUid()` returns a Promise; the extension was using it synchronously, so the page-title lookup always resolved to `null` and the button never mounted. The call is now awaited.

Only `source_commit` changed in the manifest.