### PR TITLE
Bug Fix - Workspaces

### DIFF
--- a/extensions/mlava/workspaces.json
+++ b/extensions/mlava/workspaces.json
@@ -5,6 +5,6 @@
   "tags": ["workspaces"],
   "source_url": "https://github.com/mlava/workspaces",
   "source_repo": "https://github.com/mlava/workspaces.git",
-  "source_commit": "4d9549701f40ec46d322bc7b45f008cfa040f853",
+  "source_commit": "a7ca8f8d7b6b15a839f397839ee80da72d91721c",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
Root cause. The autosave path had four compounding bugs:

A full autosave write pass ran as a side-effect of every extension load — and since Roam reloads extensions in place on every Depot update (and every dev-mode reload), each reload wrote to the graph. Under dev mode's ~2s reload cadence this alone produced a write pass every couple of seconds. The Main Content filter blocks — the two in your screenshot — were rewritten unconditionally on every pass. Every other field had an "only if different" guard; these didn't. Because updateBlock records an edit even when the string is unchanged, every pass appended versions to those exact blocks' edit history, which is the load-time cost you were seeing. The definition never converged, so even guarded writes kept firing: the create and update paths disagreed on structure (flat siblings vs nested under the page link), the code indexed children[0] on an unsorted pull, and in one branch it wrote the raw datalog result (a nested array) into the block — which never reads back equal, so it rewrote every tick, forever. A var shadowing bug leaked one pull watch per reload (cleanup removed a watch on uid "undefined" instead of the real one). Each leaked watch re-ran a full config re-scan — two recursive full-page pulls plus a topbar rebuild — on every write, from dead instances. We caught six stacked watches in a single session while instrumenting. The fix. Load now only arms the interval (an immediate save happens solely when the user toggles autosave on); every write is diff-guarded, so an unchanged layout produces zero writes per tick; children are matched by content after sorting by :block/order; pageName is normalised to a string; the shadowing is fixed and unload teardown is idempotent with a proper onunload export. Also fixed en route: autosave crashed with an uncaught assert whenever no page was open (daily-notes log, desktop app, hyphenated graph names) — it now resolves the view via getOpenView() and skips gracefully.

Verified with per-instance instrumented logging: load → zero writes; manual toggle → one-time convergence writes only; steady-state tick → zero writes; reload → watch removed by real uid, no zombie instances.

One note for affected graphs: the bug left inert nested filter blocks under the Main Content page link (as in your screenshot). We deliberately don't auto-delete user-graph blocks, so they'll remain until removed by hand — they're ignored by the loader. The accrued edit history on those blocks is Roam-side and unfortunately can't be trimmed by the extension.