### PR TITLE
Bug Fix Workspaces

### DIFF
--- a/extensions/mlava/workspaces.json
+++ b/extensions/mlava/workspaces.json
@@ -5,6 +5,6 @@
   "tags": ["workspaces"],
   "source_url": "https://github.com/mlava/workspaces",
   "source_repo": "https://github.com/mlava/workspaces.git",
-  "source_commit": "a7ca8f8d7b6b15a839f397839ee80da72d91721c",
+  "source_commit": "161f5250eea3569f4851b3bc9083ecc9e3623d90",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
clearInterval(checkInterval) is called at src/index.js:662, inside the shared cleanup closure that both the returned teardown and onunload route into, so a plain disable does clear the timer (if you were reading the minified extension.js, it's easy to miss there). But the review found a real leak by another path: autoSave(immediate=true) awaits the immediate save before arming the interval. If the extension unloads during that await — easy to hit, since the save does a dozen sequential API calls — cleanup runs first and then autoSave resumes and arms a fresh interval that nothing can ever clear, firing createWorkspace from the dead closure exactly as you described. Fixed by having cleanup set a cleanedUp flag that autoSave checks immediately before arming (src/index.js:347); a post-unload resume now returns without scheduling anything.