### PR TITLE
Update Chief of Staff

### DIFF
--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "c22ed3c5b972adb6f396cebf5c6be5fa9ca9a9de",
+  "source_commit": "1627d01d219d93b791866158cab32149291f1b1e",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }

--- a/extensions/mlava/chief-of-staff.json
+++ b/extensions/mlava/chief-of-staff.json
@@ -5,6 +5,6 @@
   "tags": ["ai", "assistant", "agent", "llm", "mcp", "automation", "tasks", "memory", "email", "calendar"],
   "source_url": "https://github.com/mlava/chief-of-staff",
   "source_repo": "https://github.com/mlava/chief-of-staff.git",
-  "source_commit": "1627d01d219d93b791866158cab32149291f1b1e",
+  "source_commit": "31662cca32634bf7d17aaa9d2c5c8b2d413e493f",
   "stripe_account": "acct_1MI2hiH4zkcxPFzj"
 }


### PR DESCRIPTION
Context: updated Google models and pricing

Tier	Model	Verdict
Mini	gemini-3.1-flash-lite ($0.25/$1.50)	Kept. Newer gemini-3.5-flash-lite exists but costs more ($0.30/$2.50) — wrong trade for the default tier that fires on every trivial query. Power	gemini-3.5-flash → gemini-3.6-flash	Changed. Strict upgrade: newer stable model, same $1.50 input, output $9.00 → $7.50. No downside. Ludicrous	gemini-3.1-pro-preview-customtools	Kept. Still the top Pro on the models page — no 3.5/3.6 Pro exists yet. Notes for review

Cost map: added "gemini-3.6-flash": [1.50, 7.50] and kept the gemini-3.5-flash entry so historical usage records still resolve. Verified no test pins the old model string; npm run build passes (only the expected ~1 MiB bundle-size warnings). Docs synced downstream in the same review: README tier table (in this PR)