### PR TITLE
Add Roamoji

### DIFF
--- a/extensions/bwydoogh/roamoji.json
+++ b/extensions/bwydoogh/roamoji.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roamoji",
+  "short_description": "Insert emoji inline with a shortcode autocomplete, triggered by typing a colon.",
+  "author": "Benny Wydooghe",
+  "tags": ["emoji", "writing", "autocomplete"],
+  "source_url": "https://github.com/bwydoogh/roamoji",
+  "source_repo": "https://github.com/bwydoogh/roamoji.git",
+  "source_commit": "646cf334c72b5627b0955e3272504396a7847ef6"
+}

--- a/extensions/bwydoogh/roamoji.json
+++ b/extensions/bwydoogh/roamoji.json
@@ -5,5 +5,6 @@
   "tags": ["emoji", "writing", "autocomplete"],
   "source_url": "https://github.com/bwydoogh/roamoji",
   "source_repo": "https://github.com/bwydoogh/roamoji.git",
-  "source_commit": "646cf334c72b5627b0955e3272504396a7847ef6"
+  "source_commit": "cef76ae07b03f37b23c76e4cd51266da7b372c4d",
+  "stripe_account": "acct_1TzsHJQdGIF0T8Wk"
 }


### PR DESCRIPTION
New extension: **Roamoji** — emoji shortcode autocomplete for the block editor.

Type `:` followed by at least two characters and a picker appears at the text cursor. `↑`/`↓` to move, `Enter`/`Tab` to insert, `Esc` to close, `Space` to close and keep typing. Typing a shortcode in full and closing it (`:tada:`) inserts immediately without opening the picker.

The picker deliberately stays closed inside Roam syntax that also uses a colon: attributes (`Status::`), times, URLs, inline code, and unclosed `[[`, `((`, `{{`.

Notes for review:

- 1870 emoji from [github/gemoji](https://github.com/github/gemoji) are bundled into `extension.js`; nothing is fetched at runtime and there are no third-party dependencies.
- `build.sh` inlines the emoji table with Node builtins only — no install step.
- Insertion goes through `document.execCommand("insertText")`, so it preserves the browser undo stack. The extension makes no `roamAlphaAPI` writes.
- Everything created in `onload` is torn down in `onunload`.

- Repo: https://github.com/bwydoogh/roamoji
- Metadata: `extensions/bwydoogh/roamoji.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)