### PR TITLE
Add Roam Codex

### DIFF
--- a/extensions/maskys/roam-codex-ai.json
+++ b/extensions/maskys/roam-codex-ai.json
@@ -2,8 +2,13 @@
   "name": "Roam Codex",
   "short_description": "Use Codex from Roam blocks and chat with it beside the native editor through a local bridge.",
   "author": "MaskyS",
-  "tags": ["ai", "codex", "chat", "agent"],
+  "tags": [
+    "ai",
+    "codex",
+    "chat",
+    "agent"
+  ],
   "source_url": "https://github.com/MaskyS/roam-codex-ai",
   "source_repo": "https://github.com/MaskyS/roam-codex-ai.git",
-  "source_commit": "0629b49eada1a2aa5e6024101955ac157560b7be"
+  "source_commit": "7dcfa547ba4d07acad776934154e68d940454881"
 }

--- a/extensions/maskys/roam-codex-ai.json
+++ b/extensions/maskys/roam-codex-ai.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roam Codex",
+  "short_description": "Use Codex from Roam blocks and chat with it beside the native editor through a local bridge.",
+  "author": "MaskyS",
+  "tags": ["ai", "codex", "chat", "agent"],
+  "source_url": "https://github.com/MaskyS/roam-codex-ai",
+  "source_repo": "https://github.com/MaskyS/roam-codex-ai.git",
+  "source_commit": "bee67f03b938bb0cb38f188dc7c491528e463633"
+}

--- a/extensions/maskys/roam-codex-ai.json
+++ b/extensions/maskys/roam-codex-ai.json
@@ -5,5 +5,5 @@
   "tags": ["ai", "codex", "chat", "agent"],
   "source_url": "https://github.com/MaskyS/roam-codex-ai",
   "source_repo": "https://github.com/MaskyS/roam-codex-ai.git",
-  "source_commit": "bee67f03b938bb0cb38f188dc7c491528e463633"
+  "source_commit": "0629b49eada1a2aa5e6024101955ac157560b7be"
 }


### PR DESCRIPTION
Adds Roam Codex by MaskyS.

Repository: https://github.com/MaskyS/roam-codex-ai
Source commit: `7dcfa547ba4d07acad776934154e68d940454881`
Bridge: `npx roam-codex-bridge` (`0.9.2` published on npm)

Roam Codex puts Codex chat beside the Roam editor and can read or change the active graph through a local bridge.

The source uses the React supplied by Roam and builds JSX with `build.sh`.

Draft while the clean-client release checks are finished.