### PR TITLE
Update Native Insert Block

### DIFF
--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "6dfa65592082d769a5285d3144e0d380e808d04f"
+  "source_commit": "c47c4a84224e04f89601d0264dbe424c45abc7b3"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "c47c4a84224e04f89601d0264dbe424c45abc7b3"
+  "source_commit": "2be782ed76ca381950e93d5c79d802d28263d390"
 }


### PR DESCRIPTION
Updates Native Insert Block from `6dfa65592082d769a5285d3144e0d380e808d04f` to `2be782ed76ca381950e93d5c79d802d28263d390`.

### What changed
- Added modifier-click actions for inserting a block above, below, as a child, or as a parent
- Added Shift-click deletion
- Improved insert-button positioning for version blocks
- Added compatibility with the redesigned Roam Document Mode: blocks with children keep the insert button aligned with the active text row instead of using outline-mode caret clearance
- Synchronized Native Insert Block CSS state classes and no-children positioning
- Fixed the Roam Depot lifecycle so the module starts only in `onload` and fully cleans up listeners, timers, and globals in `onunload`
- Added a dependency-free smoke test covering module import, lifecycle cleanup, outline positioning, and Document Mode positioning

### Verification
- `npm test`
- `npm run build`
- `node --check src/index.js`
- `node --check extension.js`
- Roam source block `((VX3yr3SJM))` synchronized and read back byte-for-byte

Only `source_commit` changed in the Depot manifest.