### PR TITLE
Add Contribution Graph – Complete History

### DIFF
--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "df21bd9e1fa666dd79591a0bf46e33a4f40ce46e"
+  "source_commit": "3cba4fd622c1b57749700d76d88684a40a2135c7"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "f17950c0c50dd0521a48210e4d854098dced4619"
+  "source_commit": "4304373867ce984e36425c14e9b603430371d56d"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "4191cc88f1a4a3bd18ad45af501bab5d9d9b04ff"
+  "source_commit": "d14a8c091bada8be8878bf49ccd73b7c774df4ad"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "864ce9880487ce83f9d87f306c9a6932ad2a8f5e"
+  "source_commit": "3525c2307f806e3fbe7ffb2b34281c08f9bd3854"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "bfc1cc8b00fb7611c8110383394f340913f1650f"
+  "source_commit": "f17950c0c50dd0521a48210e4d854098dced4619"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "d6ec8f1c61ddcd6faa8050aa1a51a3840235565f"
+  "source_commit": "07689b7dd336c6b76632f5dd144ea4f58329ab07"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "3525c2307f806e3fbe7ffb2b34281c08f9bd3854"
+  "source_commit": "4191cc88f1a4a3bd18ad45af501bab5d9d9b04ff"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "2b0cdfb32d118ba32fcf8105b7adf2ddfad7a345"
+  "source_commit": "c4a2a1b67266ad55eea483d6709e59a011301154"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "d14a8c091bada8be8878bf49ccd73b7c774df4ad"
+  "source_commit": "d6ec8f1c61ddcd6faa8050aa1a51a3840235565f"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "ccf14dc1366618eaaf52f347d06e0f559f5bd375"
+  "source_commit": "94b40655c66f897116367f116e47f256775babee"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "caa7ef537a4b11b7e1a68bb7dc56da622ac43075"
+  "source_commit": "ccf14dc1366618eaaf52f347d06e0f559f5bd375"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "332f17eb760f96f53510c348e1abbba15b1e476f"
+  "source_commit": "864ce9880487ce83f9d87f306c9a6932ad2a8f5e"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -1,0 +1,9 @@
+{
+  "name": "Contribution Graph – Complete History",
+  "short_description": "Render a GitHub-style heatmap for every year of block creation history in a Roam graph.",
+  "author": "404KSG, based on Felix Stocker's original extension",
+  "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
+  "source_url": "https://github.com/404KSG/contribution-graph",
+  "source_repo": "https://github.com/404KSG/contribution-graph.git",
+  "source_commit": "df21bd9e1fa666dd79591a0bf46e33a4f40ce46e"
+}

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "07689b7dd336c6b76632f5dd144ea4f58329ab07"
+  "source_commit": "4d9b4b1c6be10b9bb2d6a7d8fa1fa5c47183c4fb"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "c4a2a1b67266ad55eea483d6709e59a011301154"
+  "source_commit": "caa7ef537a4b11b7e1a68bb7dc56da622ac43075"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "4304373867ce984e36425c14e9b603430371d56d"
+  "source_commit": "332f17eb760f96f53510c348e1abbba15b1e476f"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "4d9b4b1c6be10b9bb2d6a7d8fa1fa5c47183c4fb"
+  "source_commit": "2b0cdfb32d118ba32fcf8105b7adf2ddfad7a345"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "3cba4fd622c1b57749700d76d88684a40a2135c7"
+  "source_commit": "7f69e23886c13ed3ef19234e3d76c6a18156f39a"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "7f69e23886c13ed3ef19234e3d76c6a18156f39a"
+  "source_commit": "bfc1cc8b00fb7611c8110383394f340913f1650f"
 }


### PR DESCRIPTION
## Purpose

Add Contribution Graph – Complete History to Roam Depot. The extension renders a GitHub-style calendar heatmap for every year from the graph's earliest dated block through the current year.

## Source and attribution

- Source: https://github.com/404KSG/contribution-graph
- Locked source commit: ccf14dc1366618eaaf52f347d06e0f559f5bd375
- Based on Felix Stocker's original project: https://github.com/Dagulf795/contribution-graph
- The original MIT license and attribution are retained.

## Main features

- Renders complete block-creation history without a rolling-year cutoff.
- Defaults to the entire graph and optionally filters to the current Roam user.
- Shows Days in Roam, longest streak, current streak, and total blocks in centered stat cells.
- Keeps live dialog statistics and the complete-history PNG export visually consistent.
- Distinguishes future dates, dates before the first block, and historical zero-activity days.
- Uses a compact Roam/Blueprint-style single-column annual layout with responsive controls and accessible modal focus behavior.
- Exports the complete history as a crisp 3x PNG through the system share sheet, clipboard, or local download.
- Avoids startup queries, reuses a short in-memory cache, and yields while aggregating large histories.
- Has no runtime dependencies, analytics, external services, or extension-initiated network requests.

## Verification

- 24 Node tests pass, covering history aggregation, calendar semantics, centered screenshots, cache behavior, error recovery, and modal accessibility.
- The 500,000-timestamp benchmark passes across 11 years.
- Repeated builds produce identical JavaScript and CSS hashes.
- Syntax checks pass and npm audit reports zero vulnerabilities.
