### PR TITLE
Restore Native Insert Block v0.9.2 behavior

### DIFF
--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "c069e9e1059c1e063e046d08e4a8390b99b92fcf"
+  "source_commit": "6bc754b26309205247c3cbd2e93f45a6bb776996"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "cf67191a8b4152fa4e17dbedbef4768399008fd6"
+  "source_commit": "5f0a97820dd68d1a69ce39e4f8300bed50160284"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -1,9 +1,9 @@
 {
   "name": "Native Insert Block",
-  "short_description": "Insert, nest, wrap, or delete blocks from one Roam-native hover control.",
+  "short_description": "A minimal plugin that adds a native-feeling 'Insert Block' button on hover in Roam Research.",
   "author": "404KSG",
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "f91231c95ead03eae87212bf125f46950b847351"
+  "source_commit": "cf67191a8b4152fa4e17dbedbef4768399008fd6"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "2be782ed76ca381950e93d5c79d802d28263d390"
+  "source_commit": "28c28188c9680706f371f6ec5417795b75f8f973"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "6bc754b26309205247c3cbd2e93f45a6bb776996"
+  "source_commit": "9a7a01a878f5ada8b773fa0d1bf84fe22a9b1729"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "5f0a97820dd68d1a69ce39e4f8300bed50160284"
+  "source_commit": "669d4c34b34b6b96b66b1c46e216f6d0592e645d"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "2594d15ed69fb8ea858e1b65de82e406dd6e642d"
+  "source_commit": "41a6d9e0c025ef4610edd20d50b6ea5d7ad5457d"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "b58693872253781767c7e86d5fdfca8d68718182"
+  "source_commit": "b3f12c63bcd195cd371701df15b04b8d37b95060"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "9a7a01a878f5ada8b773fa0d1bf84fe22a9b1729"
+  "source_commit": "f91231c95ead03eae87212bf125f46950b847351"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "f6af769a9b79f37ecaef5b8271c293dad71a00b6"
+  "source_commit": "c069e9e1059c1e063e046d08e4a8390b99b92fcf"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "41a6d9e0c025ef4610edd20d50b6ea5d7ad5457d"
+  "source_commit": "fb0c4baef9878be89ad3e326c88b1237ad099503"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "fd746a32808792dd561b8008c9d0cff3e12a8740"
+  "source_commit": "1d13d4cdde1fb6a6543c18c90329afce903dc4dc"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "b3f12c63bcd195cd371701df15b04b8d37b95060"
+  "source_commit": "2594d15ed69fb8ea858e1b65de82e406dd6e642d"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -1,9 +1,9 @@
 {
   "name": "Native Insert Block",
-  "short_description": "A minimal plugin that adds a native-feeling 'Insert Block' button on hover in Roam Research.",
+  "short_description": "Insert, nest, wrap, or delete blocks from one Roam-native hover control.",
   "author": "404KSG",
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "28c28188c9680706f371f6ec5417795b75f8f973"
+  "source_commit": "fd746a32808792dd561b8008c9d0cff3e12a8740"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "1d13d4cdde1fb6a6543c18c90329afce903dc4dc"
+  "source_commit": "f6af769a9b79f37ecaef5b8271c293dad71a00b6"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "669d4c34b34b6b96b66b1c46e216f6d0592e645d"
+  "source_commit": "b58693872253781767c7e86d5fdfca8d68718182"
 }


### PR DESCRIPTION
## Summary

Restore Native Insert Block to the previously accepted v0.9.2 behavior. The v0.9.3 bullet/caret positioning change has been reverted in the source repository.

## Source

- Repository: https://github.com/404KSG/roam-native-insert-block
- Source commit: `fb0c4baef9878be89ad3e326c88b1237ad099503`
- Restored baseline: `v0.9.2` (`2594d15`)

## Verification

- The restored working tree is identical to the v0.9.2 baseline.
- Build and syntax checks pass.
- All 20 action and lifecycle tests pass.
- Smoke and coverage checks pass.