### PR TITLE
Add Roam Remove Tag extension

### DIFF
--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -5,5 +5,5 @@
   "tags": ["tags", "blocks", "editing", "productivity"],
   "source_url": "https://github.com/404KSG/roam-remove-tag",
   "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
-  "source_commit": "00b4b9f43a60bf77341910f4726ef049bc8ab2b6"
+  "source_commit": "b41f8cf4c4a33d9c1004a92e20779b6db95bd8f8"
 }

--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -1,9 +1,9 @@
 {
   "name": "Roam Remove Tag",
-  "short_description": "Safely remove the current-page tag or all tags from one or many Roam blocks.",
+  "short_description": "Safely remove a block's page tag or all tags from one or many Roam blocks.",
   "author": "404KSG",
   "tags": ["tags", "blocks", "editing", "productivity"],
   "source_url": "https://github.com/404KSG/roam-remove-tag",
   "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
-  "source_commit": "b41f8cf4c4a33d9c1004a92e20779b6db95bd8f8"
+  "source_commit": "b044c5f37f56a86d5cd9d9acb6d9bfb69b22a2b5"
 }

--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -5,5 +5,5 @@
   "tags": ["tags", "blocks", "editing", "productivity"],
   "source_url": "https://github.com/404KSG/roam-remove-tag",
   "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
-  "source_commit": "f6b652e24be8530a8d00a8b3d970f36e9247a341"
+  "source_commit": "4e91bf6efbe7829459a320975ef50262ecd3d0df"
 }

--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -5,5 +5,5 @@
   "tags": ["tags", "blocks", "editing", "productivity"],
   "source_url": "https://github.com/404KSG/roam-remove-tag",
   "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
-  "source_commit": "cef2d2ae0a21d5cd7e4867080d28075e18073ac7"
+  "source_commit": "ee3ee5ea1a0c61ada0863a521bc1763092ec3373"
 }

--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roam Remove Tag",
+  "short_description": "Safely remove the current-page tag or all tags from one or many Roam blocks.",
+  "author": "404KSG",
+  "tags": ["tags", "blocks", "editing", "productivity"],
+  "source_url": "https://github.com/404KSG/roam-remove-tag",
+  "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
+  "source_commit": "00b4b9f43a60bf77341910f4726ef049bc8ab2b6"
+}

--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -5,5 +5,5 @@
   "tags": ["tags", "blocks", "editing", "productivity"],
   "source_url": "https://github.com/404KSG/roam-remove-tag",
   "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
-  "source_commit": "4e91bf6efbe7829459a320975ef50262ecd3d0df"
+  "source_commit": "cef2d2ae0a21d5cd7e4867080d28075e18073ac7"
 }

--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -5,5 +5,5 @@
   "tags": ["tags", "blocks", "editing", "productivity"],
   "source_url": "https://github.com/404KSG/roam-remove-tag",
   "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
-  "source_commit": "b044c5f37f56a86d5cd9d9acb6d9bfb69b22a2b5"
+  "source_commit": "f6b652e24be8530a8d00a8b3d970f36e9247a341"
 }


### PR DESCRIPTION
## Summary

- Add **Roam Remove Tag** to Roam Depot.
- Provide single-block and multi-select commands for removing each block source-page tag or all tags and star aliases.
- Preserve URLs, arbitrary backtick code spans, unrelated tags, children, and existing whitespace.
- Prevent duplicate Depot and roam/js runtimes, roll back partial registration, and use native Roam Blueprint notifications.

## Source

- Repository: https://github.com/404KSG/roam-remove-tag
- Commit: `ee3ee5ea1a0c61ada0863a521bc1763092ec3373`
- Version: `0.9.0`

## Validation

- 19 behavior and lifecycle tests pass.
- Both generated bundles pass syntax validation and are verified by CI.
- npm audit reports 0 vulnerabilities.
- Draft test shorthand: `404KSG+roam-remove-tag+1407`

Ready for Roam Depot review.