### PR TITLE
Add Contribution Graph – Complete History

### DIFF
--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "d91b03898e5651536dfd9861f3f22d0dae82ed20"
+  "source_commit": "19342f8cb3a7ec59a9fd594c926eef97023d01c3"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "19342f8cb3a7ec59a9fd594c926eef97023d01c3"
+  "source_commit": "3686d356e14c8ee0924ceb7b7c000040730e25fc"
 }

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -1,0 +1,9 @@
+{
+  "name": "Contribution Graph – Complete History",
+  "short_description": "Render a GitHub-style heatmap for every year of block creation history in a Roam graph.",
+  "author": "404KSG, based on Felix Stocker's original extension",
+  "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
+  "source_url": "https://github.com/404KSG/contribution-graph",
+  "source_repo": "https://github.com/404KSG/contribution-graph.git",
+  "source_commit": "94b40655c66f897116367f116e47f256775babee"
+}

--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "94b40655c66f897116367f116e47f256775babee"
+  "source_commit": "d91b03898e5651536dfd9861f3f22d0dae82ed20"
 }


### PR DESCRIPTION
## Purpose

Add Contribution Graph – Complete History to Roam Depot. It renders complete Roam block-creation history as a compact yearly heatmap.

This clean submission supersedes #1405 after testing and UI refinement were completed.

## Source and attribution

- Source: https://github.com/404KSG/contribution-graph
- Locked source commit: `3686d356e14c8ee0924ceb7b7c000040730e25fc`
- Based on Felix Stocker original project: https://github.com/Dagulf795/contribution-graph
- Original MIT license and attribution retained.

## Highlights

- Displays every year from the earliest dated block through the current year.
- Renders years progressively so complete-history views remain responsive.
- Supports entire-graph and current-user scopes.
- Shows Days in Roam, longest streak, current streak, and total blocks.
- Exports the complete history as a crisp 3x PNG.
- Performs no startup query and uses no analytics or external services.

## Verification

- 25 Node tests pass.
- The 500,000-timestamp, 11-year benchmark passes.
- Repeated builds are deterministic and npm audit reports zero vulnerabilities.
