### PR TITLE
Add Drag References extension

### DIFF
--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -1,0 +1,9 @@
+{
+  "name": "Drag References",
+  "short_description": "Create aliases, source citations, and embed paths by modifier-dragging Roam blocks.",
+  "author": "404KSG",
+  "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
+  "source_url": "https://github.com/404KSG/roam-drag-references",
+  "source_repo": "https://github.com/404KSG/roam-drag-references.git",
+  "source_commit": "e5389b28cfc47f3dd739f14a830825e7ec96ff6d"
+}

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "c7d934ba0144f6bc774cd4d81ea8af24d1bd54bb"
+  "source_commit": "546150bccff65092c0a2c953ba21b459029aee8d"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "af5454d570aa911d63793fff589135ef0dbc661d"
+  "source_commit": "a7d37d81fa482190192cf4d3c2cef915e850d0cd"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -1,9 +1,9 @@
 {
   "name": "Drag References",
-  "short_description": "Create aliases, source citations, and embed paths by modifier-dragging Roam blocks.",
+  "short_description": "Create references and embeds by dragging blocks—built for fluid writing and Roam's core workflow.",
   "author": "404KSG",
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "e5389b28cfc47f3dd739f14a830825e7ec96ff6d"
+  "source_commit": "92eda8df5e79c71fe2bfb9b504506804a3c88307"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "146a3e80f64738879e9355a7e007fbdc25d3460a"
+  "source_commit": "8d3a41df1756b67c381bfee1e40aa3fd17024277"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "c641cedc3c32a43abf65db58e6a4254a66e7ed19"
+  "source_commit": "146a3e80f64738879e9355a7e007fbdc25d3460a"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "92eda8df5e79c71fe2bfb9b504506804a3c88307"
+  "source_commit": "af5454d570aa911d63793fff589135ef0dbc661d"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "546150bccff65092c0a2c953ba21b459029aee8d"
+  "source_commit": "52aa2e04b5e7bf9b9682bbf668c175e4a8cd34ee"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "8d3a41df1756b67c381bfee1e40aa3fd17024277"
+  "source_commit": "c7d934ba0144f6bc774cd4d81ea8af24d1bd54bb"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "a7d37d81fa482190192cf4d3c2cef915e850d0cd"
+  "source_commit": "c641cedc3c32a43abf65db58e6a4254a66e7ed19"
 }


### PR DESCRIPTION
## Summary

- Add **Drag References** to Roam Depot.
- Create aliases with Command-drag, source citations with Control-drag, and embed paths with Shift-drag.
- Preserve Roam native drag and Option-drag behavior.
- Copy every successful reference to the clipboard.
- Support sibling and child placement with native-style feedback.
- Keep source context inside the writing flow while making Roam block references faster to use.

## Source

- Repository: https://github.com/404KSG/roam-drag-references
- Commit: `52aa2e04b5e7bf9b9682bbf668c175e4a8cd34ee`
- Version: `0.3.16`
- Demo: included in the source README as an inline GIF with a full-quality MP4 link.

## Validation

- `npm test`: 50 tests passed.
- `npm run check`: source and generated bundles pass syntax validation.
- Depot build check passed.
- PR shorthand `404KSG+roam-drag-references+1409` was verified in Roam with native drag, Option-drag, Command-drag, Control-drag, and Shift-drag.
- No analytics or external graph-data transmission.

Ready for Roam Depot review.