### PR TITLE
Add QuickCuts extension

### DIFF
--- a/extensions/derwin/roam-quick-cuts.json
+++ b/extensions/derwin/roam-quick-cuts.json
@@ -1,0 +1,10 @@
+{
+  "name": "QuickCuts",
+  "short_description": "Jump to your left-sidebar Shortcuts with number hotkeys.",
+  "author": "Derwin He",
+  "tags": ["shortcuts", "navigation"],
+  "source_url": "https://github.com/WalnutDerwin/roam-quick-cuts",
+  "source_repo": "https://github.com/WalnutDerwin/roam-quick-cuts.git",
+  "source_commit": "373cbba9eddc00025a00c8a633dc9bf08fd26dee",
+  "stripe_account": "acct_1TvulWQfnUG7gVqv"
+}


### PR DESCRIPTION
## Why it's needed
In Roam Research, you can add Pages as Shortcuts and open them from the left sidebar, but there is no built-in way to jump to them with keyboard shortcuts. I frequently need to switch between my Journal, Tasks, Projects, and other Pages, and I want to edit them with focus in the main window, not just keep them as references in the right sidebar. Clicking through the sidebar every time breaks that flow.

## What it does
So I add a small, simple extension, QuickCuts, that lets you open your sidebar Shortcuts with number hotkeys. You can open the Nth Shortcut either in the main window or in the right sidebar, so you can navigate between your most-used Pages without leaving the keyboard.