### PR TITLE
Add Native AI Agents extension

### DIFF
--- a/extensions/404KSG/roam-native-ai-agents.json
+++ b/extensions/404KSG/roam-native-ai-agents.json
@@ -5,5 +5,5 @@
   "tags": ["AI", "agent", "block", "writing", "zettelkasten", "knowledge management"],
   "source_url": "https://github.com/404KSG/roam-native-ai-agents",
   "source_repo": "https://github.com/404KSG/roam-native-ai-agents.git",
-  "source_commit": "564f7211a8b4913976b06be00abc58304f6d1ce8"
+  "source_commit": "ca0966107b917da47441b95341699156cb2397ec"
 }

--- a/extensions/404KSG/roam-native-ai-agents.json
+++ b/extensions/404KSG/roam-native-ai-agents.json
@@ -1,0 +1,9 @@
+{
+  "name": "Native AI Agents",
+  "short_description": "Turn Roam blocks into working notes, critiques, and durable atomic notes with three native-feeling AI agents.",
+  "author": "404KSG",
+  "tags": ["AI", "agent", "block", "writing", "zettelkasten", "knowledge management"],
+  "source_url": "https://github.com/404KSG/roam-native-ai-agents",
+  "source_repo": "https://github.com/404KSG/roam-native-ai-agents.git",
+  "source_commit": "3accddb5ecc9ea468ffe190ce6c8d470aa5fd4b6"
+}

--- a/extensions/404KSG/roam-native-ai-agents.json
+++ b/extensions/404KSG/roam-native-ai-agents.json
@@ -5,5 +5,5 @@
   "tags": ["AI", "agent", "block", "writing", "zettelkasten", "knowledge management"],
   "source_url": "https://github.com/404KSG/roam-native-ai-agents",
   "source_repo": "https://github.com/404KSG/roam-native-ai-agents.git",
-  "source_commit": "ca0966107b917da47441b95341699156cb2397ec"
+  "source_commit": "adfb40659e6689a71ecd2603d49a66c7dab6f5a3"
 }

--- a/extensions/404KSG/roam-native-ai-agents.json
+++ b/extensions/404KSG/roam-native-ai-agents.json
@@ -5,5 +5,5 @@
   "tags": ["AI", "agent", "block", "writing", "zettelkasten", "knowledge management"],
   "source_url": "https://github.com/404KSG/roam-native-ai-agents",
   "source_repo": "https://github.com/404KSG/roam-native-ai-agents.git",
-  "source_commit": "4f05fdcdd26cfbb1f3f6c20d5043b4d89a14d21b"
+  "source_commit": "564f7211a8b4913976b06be00abc58304f6d1ce8"
 }

--- a/extensions/404KSG/roam-native-ai-agents.json
+++ b/extensions/404KSG/roam-native-ai-agents.json
@@ -5,5 +5,5 @@
   "tags": ["AI", "agent", "block", "writing", "zettelkasten", "knowledge management"],
   "source_url": "https://github.com/404KSG/roam-native-ai-agents",
   "source_repo": "https://github.com/404KSG/roam-native-ai-agents.git",
-  "source_commit": "35e80e16831946aa80cb45e1639739376baa17f4"
+  "source_commit": "4f05fdcdd26cfbb1f3f6c20d5043b4d89a14d21b"
 }

--- a/extensions/404KSG/roam-native-ai-agents.json
+++ b/extensions/404KSG/roam-native-ai-agents.json
@@ -5,5 +5,5 @@
   "tags": ["AI", "agent", "block", "writing", "zettelkasten", "knowledge management"],
   "source_url": "https://github.com/404KSG/roam-native-ai-agents",
   "source_repo": "https://github.com/404KSG/roam-native-ai-agents.git",
-  "source_commit": "3accddb5ecc9ea468ffe190ce6c8d470aa5fd4b6"
+  "source_commit": "35e80e16831946aa80cb45e1639739376baa17f4"
 }


### PR DESCRIPTION
## Summary

Adds Native AI Agents, a near-native Roam writing extension with three built-in agents:

- Synthesize turns source blocks into a complete working note.
- Critic tests claims, evidence, assumptions, and atomicity.
- Distiller creates a durable atomic note.

Pressing Enter on an `@Agent` suggestion commits and runs that Agent immediately with its focused default task. Tab keeps the choose-and-continue path for custom instructions. On a first run, saving API settings automatically resumes the pending Agent. Generated content begins as a child draft and can be kept, inserted below, promoted above, safely replace the source while preserving the original, or distilled again. API keys remain in browser storage and remote endpoints require HTTPS.

## Verification

- 34 Node behavior tests pass
- Main-window, sidebar, and outline editor IDs resolve the correct trailing Roam block UID
- Delayed native Roam commits and explicit suggestion commits are both covered
- Depot and shorthand bundles build successfully
- Source response schema is strictly validated before Roam writes
- Context reads are bounded and cancellation is rollback-safe
- This PR adds one manifest locked to `adfb40659e6689a71ecd2603d49a66c7dab6f5a3`