### PR TITLE
Add Roam Places

### DIFF
--- a/extensions/maskys/roam-places.json
+++ b/extensions/maskys/roam-places.json
@@ -10,5 +10,5 @@
   ],
   "source_url": "https://github.com/MaskyS/roam-places",
   "source_repo": "https://github.com/MaskyS/roam-places.git",
-  "source_commit": "b284ca186150558987cc5431a0f84a5f003c7049"
+  "source_commit": "397eb45861a91f048f4a7ba020b106e121511911"
 }

--- a/extensions/maskys/roam-places.json
+++ b/extensions/maskys/roam-places.json
@@ -10,5 +10,5 @@
   ],
   "source_url": "https://github.com/MaskyS/roam-places",
   "source_repo": "https://github.com/MaskyS/roam-places.git",
-  "source_commit": "aa622dcb5d445e2ff8114d9056d47a613ebd0a0c"
+  "source_commit": "def498cc30b7582a7e9bd6eec47e380071781038"
 }

--- a/extensions/maskys/roam-places.json
+++ b/extensions/maskys/roam-places.json
@@ -1,0 +1,14 @@
+{
+  "name": "Roam Places",
+  "short_description": "Find, save, and insert geocoded places without leaving the Roam block.",
+  "author": "MaskyS",
+  "tags": [
+    "places",
+    "maps",
+    "geocoding",
+    "location"
+  ],
+  "source_url": "https://github.com/MaskyS/roam-places",
+  "source_repo": "https://github.com/MaskyS/roam-places.git",
+  "source_commit": "aa622dcb5d445e2ff8114d9056d47a613ebd0a0c"
+}

--- a/extensions/maskys/roam-places.json
+++ b/extensions/maskys/roam-places.json
@@ -10,5 +10,5 @@
   ],
   "source_url": "https://github.com/MaskyS/roam-places",
   "source_repo": "https://github.com/MaskyS/roam-places.git",
-  "source_commit": "def498cc30b7582a7e9bd6eec47e380071781038"
+  "source_commit": "b284ca186150558987cc5431a0f84a5f003c7049"
 }


### PR DESCRIPTION
Adds Roam Places by MaskyS.

Repository: https://github.com/MaskyS/roam-places
Source commit: `b284ca186150558987cc5431a0f84a5f003c7049`

Roam Places finds existing located pages and online place results directly from the `/Place` command, then inserts or enriches ordinary Roam pages with readable `geo:` URI metadata. Photon works without setup; Geoapify is available as an optional keyed provider. Users can inspect or pick coordinates on an attributed OpenFreeMap map and can choose a graph-scoped search home on that map to rank nearby results first.

The extension uses Roam-provided React, ReactDOMClient, and Blueprint. MapLibre is bundled for the map surface. `build.sh` performs a clean npm install and production build.

Verification: `build.sh` succeeds and the clean source commit passes 88/88 tests.

Draft while the Roam Depot build and review checks run.