### PR TITLE
Add Roam Map

### DIFF
--- a/extensions/maskys/roam-map.json
+++ b/extensions/maskys/roam-map.json
@@ -1,0 +1,15 @@
+{
+  "name": "Roam Map",
+  "short_description": "Turn Roam pages, blocks, queries, and Datalog results into live maps.",
+  "author": "MaskyS",
+  "tags": [
+    "maps",
+    "location",
+    "queries",
+    "datalog",
+    "visualization"
+  ],
+  "source_url": "https://github.com/MaskyS/roam-map",
+  "source_repo": "https://github.com/MaskyS/roam-map.git",
+  "source_commit": "031e68e7b7e5d1c940d49edaa9ad1f05a999c8e0"
+}

--- a/extensions/maskys/roam-map.json
+++ b/extensions/maskys/roam-map.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/MaskyS/roam-map",
   "source_repo": "https://github.com/MaskyS/roam-map.git",
-  "source_commit": "031e68e7b7e5d1c940d49edaa9ad1f05a999c8e0"
+  "source_commit": "1e5b06a4ce465d1ebf1b0fe7d5feaf4a30ad7bd3"
 }


### PR DESCRIPTION
Adds Roam Map by MaskyS.

Repository: https://github.com/MaskyS/roam-map
Source commit: `031e68e7b7e5d1c940d49edaa9ad1f05a999c8e0`

Roam Map turns ordinary Roam pages, blocks, native-query results, and exact UIDs returned by fenced Datalog into live maps. It supports attributed basemap previews and saved selections, responsive resizing, source diagnostics, a synchronized results list, and source navigation in the right sidebar. Advanced graph authors can add validated MapLibre layers and use Roam's custom-component surface for marker cards and results lists.

The extension reads and watches graph data through the Roam Alpha API without rewriting location sources while rendering. It uses Roam-provided React, ReactDOMClient, and Blueprint; MapLibre is bundled for the map surface. Remote basemap and image resources remain browser-visible and provider attribution stays available in the map.

`build.sh` performs a clean npm install and production build. A clean checkout of the pinned source commit passes all 131 tests, the production build, and the bundle guard.

Draft while the Roam Depot build and review checks run.