### PR TITLE
Add Roam Grid

### DIFF
--- a/extensions/Svyk/roam-grid.json
+++ b/extensions/Svyk/roam-grid.json
@@ -5,5 +5,5 @@
   "tags": ["table", "spreadsheet", "formulas", "editing"],
   "source_url": "https://github.com/Svyk/roam-grid",
   "source_repo": "https://github.com/Svyk/roam-grid.git",
-  "source_commit": "f36cb28af188b053625553b88aa1815a115a3d7c"
+  "source_commit": "9f9c27e8d017a46a31369cacc5968d39db0b2844"
 }

--- a/extensions/Svyk/roam-grid.json
+++ b/extensions/Svyk/roam-grid.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roam Grid",
+  "short_description": "Turn a native Roam table into a spreadsheet — formulas, merges, charts, comments — cells stay ordinary blocks.",
+  "author": "Svyatoslav Kleshchev",
+  "tags": ["table", "spreadsheet", "formulas", "editing"],
+  "source_url": "https://github.com/Svyk/roam-grid",
+  "source_repo": "https://github.com/Svyk/roam-grid.git",
+  "source_commit": "f36cb28af188b053625553b88aa1815a115a3d7c"
+}


### PR DESCRIPTION
Adds Roam Grid by Svyatoslav Kleshchev.

Repository: https://github.com/Svyk/roam-grid
Source commit: `f36cb28af188b053625553b88aa1815a115a3d7c` (v0.17.0)

Roam Grid turns a native `{{table}}` into a spreadsheet — formulas, merges, sorting, resizing, charts, comments — while every cell stays an ordinary Roam block. Turning the extension off leaves the table in the graph.

Install writes nothing. Layout metadata is created on `[[roam/grid/metadata]]` only when a table is enhanced. No network requests, no telemetry, no `eval` / `new Function`, no runtime dependencies. CSS is scoped to `.rg-*` classes.

Large grids (`{{roam/grid}}` file-backed grids) are behind **Experimental — Large grids**, off by default.

`build.sh` runs `node build.mjs` (plain Node, no npm install). A clean checkout of the pinned commit passes the suite (734 tests), the secret scan, and the generated-artifact check.

README is the product page and lists everything the extension can write to a graph.