### PR TITLE
Update Native Insert Block positioning

### DIFF
--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "fb0c4baef9878be89ad3e326c88b1237ad099503"
+  "source_commit": "45cf81be8afd7520b0b8a738836686190b5d76d1"
 }

--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "45cf81be8afd7520b0b8a738836686190b5d76d1"
+  "source_commit": "e772519b16046ad1da7a28c3a8e5332ff8268708"
 }


### PR DESCRIPTION
Improves insert-button positioning for custom typography.

- Leaf Blocks align to their live Bullet geometry.
- Parent Blocks retain caret clearance and do not overlap collapse controls.

Source: `e772519b16046ad1da7a28c3a8e5332ff8268708`

Verified with `npm test`, Roam Depot Build, and Preview Publish.