### PR TITLE
Update Native Insert Block positioning

### DIFF
--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "fb0c4baef9878be89ad3e326c88b1237ad099503"
+  "source_commit": "354415dfeb2de0d2794fcb07f4e79f80f189d0b2"
 }


### PR DESCRIPTION
Supersedes closed test PRs #1415 and #1416. Old source_commit: fb0c4baef9878be89ad3e326c88b1237ad099503. New source_commit: 354415dfeb2de0d2794fcb07f4e79f80f189d0b2. Fixes Native Insert Block hover positioning for outline parents. Parent blocks preserve the theme's original CSS baseline whenever it already clears the native collapse caret, and apply only the minimum geometry-based offset when needed. This avoids dropping the entire 24px plus container below the caret. Leaf Bullet anchoring and Document Mode fallback are unchanged. Verified with npm test (lifecycle smoke test, 20 action tests, coverage), syntax checks, and git diff --check. This Depot diff only changes extensions/404KSG/roam-native-insert-block.json source_commit.