### PR TITLE
Add Roam Focus Logbook

### DIFF
--- a/extensions/404KSG/roam-focus-logbook.json
+++ b/extensions/404KSG/roam-focus-logbook.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roam Focus Logbook",
+  "short_description": "A minimal single-focus clock, Pomodoro, and Org-style LOGBOOK report for Roam TODOs.",
+  "author": "404KSG",
+  "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
+  "source_url": "https://github.com/404KSG/roam-focus-logbook",
+  "source_repo": "https://github.com/404KSG/roam-focus-logbook.git",
+  "source_commit": "ce9c84397d0ae4bd435a835b58f5d819d0c3e683"
+}


### PR DESCRIPTION
## Summary

- Adds Roam Focus Logbook as a Draft Depot preview.
- Provides a minimal single-open focus clock for Roam TODOs, an independent Pomodoro, and Org-style LOGBOOK reporting.
- Uses inline visual controls without writing macros into task text.
- Keeps all task and timing data in the local Roam graph.

## Privacy

- No network requests or analytics.
- No Agent integration.
- Pomodoro preferences use graph-scoped Roam extension settings.

## Verification

- npm test: 10 test files, 31 tests passed.
- npm run check: passed.
- npm run lint: passed.
- npm run build: passed.
- Source build.sh passed from a clean checkout at the pinned source commit.
- Generated extension.js exposes the required default onload/onunload ESM contract.
- Clean-checkout bundle SHA-256 matches the source repository bundle.

## Draft preview

This PR is intentionally Draft so the shorthand preview can be tested before marketplace review. It should not be merged until live Roam preview validation is complete.