### PR TITLE
Add Task Tracker

### DIFF
--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "20d03d1238e0ba522c7ef15e5d6480d70ad237a8"
+  "source_commit": "d60f32a48553d1fd29b93838916dc237ca0369c6"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,9 +1,9 @@
 {
   "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style Roam task clocks with a quiet native dashboard, paused-session recovery, Pomodoro, and task rollups.",
+  "short_description": "Org-style Roam task clocks with an embedded activity rail, paused-session recovery, Pomodoro, and task rollups.",
   "author": "forrestchang, 404KSG",
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "671f3d20240b47652f5de3ea3fbb799bb647c81b"
+  "source_commit": "5f2e7c73aa68f57c344d9b9cc3969f160f7516ad"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "7f6feab4474162ec5f5254a66833fa2825b2c2bc"
+  "source_commit": "a23556b71668fd13d8f47f942531e3cacc79cc81"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "5fe089235b27819cadf4b8fb319cdca8be9bd909"
+  "source_commit": "8f68984c8d9ad67a5ee7d25f23f5ab17e41bb787"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,9 +1,9 @@
 {
   "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style Roam task clocks with an embedded activity rail, paused-session recovery, Pomodoro, and task rollups.",
+  "short_description": "Org-style Roam task clocks with Linear-inspired dashboard panels, paused-session recovery, Pomodoro, and task rollups.",
   "author": "forrestchang, 404KSG",
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "1fde5fe1c117ec0ca671cadc9fb80a862cd7f61c"
+  "source_commit": "333f166159c95027e94e77622e4f5ba0495f6392"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "1698c8fc5e90e57ea1329296e5b7d66b637c19b2"
+  "source_commit": "e5d574df2897a304fdab64d70524fb4e8970a13e"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "ef26005555c98bb19a8c106c441fcdb206db8cc5"
+  "source_commit": "83c7919530081e7cf92122f98529c831cc080722"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "2d8a188dbc8c8ef5b461830998bd86a002c1dd55"
+  "source_commit": "6f11d11bdcab7bdcea48242173a8caf460395bed"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "662e0f1cb936c3098d8fe7b76520cd7394e29525"
+  "source_commit": "94e4164cde1be1e86a613de764d167a8e46b300b"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "c5535c0528722814717f11362c834327d2a19a3d"
+  "source_commit": "ef26005555c98bb19a8c106c441fcdb206db8cc5"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "52a1032a3396ce374da50c63a065d9b5125d28cc"
+  "source_commit": "12866923c2118f521bc849dbfe3049860b6fa25e"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "bd142ba9349a8e717e250599d6d6693f9293cb87"
+  "source_commit": "f285fc3"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "ec85ec8e891aeb2c7be681438665921341ba9482"
+  "source_commit": "7fe9195a312124d734b1b1d84de70205d44914ec"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "6f11d11bdcab7bdcea48242173a8caf460395bed"
+  "source_commit": "db7d275494841e143644e13b8d75469a29100814"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "83c7919530081e7cf92122f98529c831cc080722"
+  "source_commit": "54db3aada5e84e3a5782687cbe20e7965bd7a308"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "1c60dc5de0a4d6efa6c268f8de60abad83623e45"
+  "source_commit": "1a02c1ce100bec0b0ea1b4bf9d588532a8441233"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "1daf59afb9b82f6a8e3141d3dbc94463d78ab853"
+  "source_commit": "6353ddecc3e88d13462066eb2a80890f38de1b8d"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "823198e2355ad0718fa1cccc2e99b0eecb1a1406"
+  "source_commit": "43d6696c764ceeb9a8686fb91d9b7c9a06f8d03d"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "02301510f55546b5f3bf054dcaa73750a0266ee7"
+  "source_commit": "3d769d9f87cb3e55b785592536008bbd60f8754c"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "d05e8db50e7963a84f3875e609a5772c446b4af9"
+  "source_commit": "bf06a77375d5b9988e757d9694f796dd8b910e00"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "bf06a77375d5b9988e757d9694f796dd8b910e00"
+  "source_commit": "644f48a25f912052b1341f164117c19c94fa1ebe"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "5d310a04650d64b30c1d0dff5a773cbfa3d897a9"
+  "source_commit": "961dece75f00db982a6e757a26c798f9206dc48e"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,6 +1,6 @@
 {
   "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style single-focus task clocks with a compact Active Threads panel, 45-minute Pomodoro, recovery, and task rollups.",
+  "short_description": "Org-style single-focus clocks with Active Threads, a hierarchical Today task pool, 45-minute Pomodoro, recovery, and rollups.",
   "author": "forrestchang, 404KSG",
   "tags": [
     "productivity",
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "b33dd4b143160b9dc3a964d862e19b81d4869d2b"
+  "source_commit": "823198e2355ad0718fa1cccc2e99b0eecb1a1406"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "db7d275494841e143644e13b8d75469a29100814"
+  "source_commit": "1c60dc5de0a4d6efa6c268f8de60abad83623e45"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "f285fc3"
+  "source_commit": "843da3f0ee5736382afcff56cc71494b086934ea"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "3d769d9f87cb3e55b785592536008bbd60f8754c"
+  "source_commit": "1d3efdb2b9d12759c0e781339b03f7b03b8a201a"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "e12f9a6eda5e01184fb0f01e5e7b63b417279eaa"
+  "source_commit": "21a1a974f94c1a9c3258f0966f9e1e37f13446f5"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "1d3efdb2b9d12759c0e781339b03f7b03b8a201a"
+  "source_commit": "2183c588733d98fdfeca923a931157fb441ff90e"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "8beb60e910900d63c10674e4d0d1226f3ac51253"
+  "source_commit": "697dbac5d9c624b1d9ac55de359af6fbbb506c8c"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "af1cdf6920057b2da3d0728210cfe81ddb73b433"
+  "source_commit": "b33dd4b143160b9dc3a964d862e19b81d4869d2b"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "674f12257ee93e29bface6786936b02b74959984"
+  "source_commit": "af1cdf6920057b2da3d0728210cfe81ddb73b433"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "d1fea326c2a7d9a6716575f2710eb5aac1b7c9e1"
+  "source_commit": "ec19c68b1fdb269ebd070064887dfc62c8fac2ae"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -2,8 +2,14 @@
   "name": "Roam Logbook – 404KSG",
   "short_description": "Org-style Roam task clocks with Linear-inspired dashboard panels, paused-session recovery, Pomodoro, and task rollups.",
   "author": "forrestchang, 404KSG",
-  "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
+  "tags": [
+    "productivity",
+    "time tracking",
+    "pomodoro",
+    "TODO",
+    "logbook"
+  ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "09c22f41067dc6318aabd4336f3f70c399178dc2"
+  "source_commit": "f0e8a5f48a0d22088885625b8c12455e2143759e"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "1a02c1ce100bec0b0ea1b4bf9d588532a8441233"
+  "source_commit": "e12f9a6eda5e01184fb0f01e5e7b63b417279eaa"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,6 +1,6 @@
 {
   "name": "Task Tracker",
-  "short_description": "Single-focus time tracking with Active Threads, a hierarchical Today task pool, complete context paths, Pomodoro, recovery, and rollups.",
+  "short_description": "Single-focus time tracking with Active Threads, a hierarchical Today task pool, Pomodoro, recovery, and task rollups.",
   "author": "forrestchang, 404KSG",
   "tags": [
     "productivity",
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "2bb5662fdc640e3164fa00cb14f4369a069ca9d3"
+  "source_commit": "c84a4bf1e32413d3773f00b973a1a58e5ead2545"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "0855a5b8ce85701a4f1de236946ad35a9c7643a9"
+  "source_commit": "2bb5662fdc640e3164fa00cb14f4369a069ca9d3"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "3ee8d001be3a63ec5b23f1b8792db9f14a06be9f"
+  "source_commit": "e3be44e06cd4b50efb072ef305024c2dea862a92"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "19d3cd30f076826d3ff8d4dcb37d203c3a221c04"
+  "source_commit": "440e1b6a6cab68d3e73bb585c94c8e2f358bf64f"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,15 +1,16 @@
 {
-  "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style single-focus clocks with Active Threads, a hierarchical Today task pool, 45-minute Pomodoro, recovery, and rollups.",
+  "name": "Task Tracker",
+  "short_description": "Single-focus time tracking with Active Threads, a hierarchical Today task pool, complete context paths, Pomodoro, recovery, and rollups.",
   "author": "forrestchang, 404KSG",
   "tags": [
     "productivity",
     "time tracking",
     "pomodoro",
     "TODO",
+    "task management",
     "logbook"
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "644f48a25f912052b1341f164117c19c94fa1ebe"
+  "source_commit": "0855a5b8ce85701a4f1de236946ad35a9c7643a9"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "c2504e75637ee0022c2ba017dedb1c0883e50f64"
+  "source_commit": "1daf59afb9b82f6a8e3141d3dbc94463d78ab853"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,6 +1,6 @@
 {
   "name": "Task Tracker",
-  "short_description": "Single-focus time tracking with Active Threads, a hierarchical Today task pool, Pomodoro, recovery, and task rollups.",
+  "short_description": "Single-focus task and time tracking for Roam Research.",
   "author": "forrestchang, 404KSG",
   "tags": [
     "productivity",
@@ -10,7 +10,7 @@
     "task management",
     "logbook"
   ],
-  "source_url": "https://github.com/404KSG/roam-logbook",
-  "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "5a3e786af68f899ad9dc0e1188c8a5eb37f927f5"
+  "source_url": "https://github.com/404KSG/roam-task-tracker",
+  "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
+  "source_commit": "155fa3c18d07a5eff0275a686c61c344bd939064"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "5e757eb9a4151c7d8bafd3feddd547e0f30763bf"
+  "source_commit": "5fe089235b27819cadf4b8fb319cdca8be9bd909"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "636dae70cc329fbdf7c5dabe6bd3978e6166fdd2"
+  "source_commit": "ec85ec8e891aeb2c7be681438665921341ba9482"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "94e4164cde1be1e86a613de764d167a8e46b300b"
+  "source_commit": "d1fea326c2a7d9a6716575f2710eb5aac1b7c9e1"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "2b871d0d213a601fb3c162c6b8f230392c116263"
+  "source_commit": "c5535c0528722814717f11362c834327d2a19a3d"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "d7f79df0eb38a8ca4b69d3cd7e671a048ed03d83"
+  "source_commit": "8beb60e910900d63c10674e4d0d1226f3ac51253"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "b25c2dda8ebd97303d217e947e653ece15cd60ab"
+  "source_commit": "2b871d0d213a601fb3c162c6b8f230392c116263"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "333f166159c95027e94e77622e4f5ba0495f6392"
+  "source_commit": "09c22f41067dc6318aabd4336f3f70c399178dc2"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "e5d574df2897a304fdab64d70524fb4e8970a13e"
+  "source_commit": "64fcf8b3a1666d0f3aa7dab03a6b9f143f0bcfb6"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "fa773e77d3276d533cfe779297b3622491861e90"
+  "source_commit": "d7f79df0eb38a8ca4b69d3cd7e671a048ed03d83"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "a23556b71668fd13d8f47f942531e3cacc79cc81"
+  "source_commit": "20d03d1238e0ba522c7ef15e5d6480d70ad237a8"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "f0e8a5f48a0d22088885625b8c12455e2143759e"
+  "source_commit": "5e757eb9a4151c7d8bafd3feddd547e0f30763bf"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "64fcf8b3a1666d0f3aa7dab03a6b9f143f0bcfb6"
+  "source_commit": "437233d1abfdf295aadbdcaf34ed52c3f36f5851"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "c84a4bf1e32413d3773f00b973a1a58e5ead2545"
+  "source_commit": "5a3e786af68f899ad9dc0e1188c8a5eb37f927f5"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "d60f32a48553d1fd29b93838916dc237ca0369c6"
+  "source_commit": "662e0f1cb936c3098d8fe7b76520cd7394e29525"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "961dece75f00db982a6e757a26c798f9206dc48e"
+  "source_commit": "19d3cd30f076826d3ff8d4dcb37d203c3a221c04"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "6353ddecc3e88d13462066eb2a80890f38de1b8d"
+  "source_commit": "3ee8d001be3a63ec5b23f1b8792db9f14a06be9f"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,6 +1,6 @@
 {
   "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style single-focus task clocks with a compact Active Work panel, 45-minute Pomodoro, recovery, and task rollups.",
+  "short_description": "Org-style single-focus task clocks with a compact Active Threads panel, 45-minute Pomodoro, recovery, and task rollups.",
   "author": "forrestchang, 404KSG",
   "tags": [
     "productivity",
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "54db3aada5e84e3a5782687cbe20e7965bd7a308"
+  "source_commit": "c96c1c9a42c8664af59dff868339c5d0b9b83f7c"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "9c6977d5dced8bc62ef551f660fe92907769ff1b"
+  "source_commit": "636dae70cc329fbdf7c5dabe6bd3978e6166fdd2"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "12866923c2118f521bc849dbfe3049860b6fa25e"
+  "source_commit": "5d310a04650d64b30c1d0dff5a773cbfa3d897a9"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,9 +1,9 @@
 {
   "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style Roam task clocks with a native dashboard, Pomodoro, and task rollups.",
+  "short_description": "Org-style Roam task clocks with a quiet native dashboard, paused-session recovery, Pomodoro, and task rollups.",
   "author": "forrestchang, 404KSG",
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "ec19c68b1fdb269ebd070064887dfc62c8fac2ae"
+  "source_commit": "671f3d20240b47652f5de3ea3fbb799bb647c81b"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "155fa3c18d07a5eff0275a686c61c344bd939064"
+  "source_commit": "fa773e77d3276d533cfe779297b3622491861e90"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "437233d1abfdf295aadbdcaf34ed52c3f36f5851"
+  "source_commit": "d05e8db50e7963a84f3875e609a5772c446b4af9"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,6 +1,6 @@
 {
   "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style Roam task clocks with a compact Roam/Linear dashboard, paused-session recovery, Pomodoro, and task rollups.",
+  "short_description": "Org-style single-focus task clocks with a compact Active Work panel, 45-minute Pomodoro, recovery, and task rollups.",
   "author": "forrestchang, 404KSG",
   "tags": [
     "productivity",
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "21a1a974f94c1a9c3258f0966f9e1e37f13446f5"
+  "source_commit": "79a3e8943d05c4ac192bfa9979d4c4720cd11fec"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -12,5 +12,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-task-tracker",
   "source_repo": "https://github.com/404KSG/roam-task-tracker.git",
-  "source_commit": "697dbac5d9c624b1d9ac55de359af6fbbb506c8c"
+  "source_commit": "9c6977d5dced8bc62ef551f660fe92907769ff1b"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "83c523a65470425baea6c6f5c88a44b315eb99c1"
+  "source_commit": "b25c2dda8ebd97303d217e947e653ece15cd60ab"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "43d6696c764ceeb9a8686fb91d9b7c9a06f8d03d"
+  "source_commit": "1698c8fc5e90e57ea1329296e5b7d66b637c19b2"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "c96c1c9a42c8664af59dff868339c5d0b9b83f7c"
+  "source_commit": "02301510f55546b5f3bf054dcaa73750a0266ee7"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "5f2e7c73aa68f57c344d9b9cc3969f160f7516ad"
+  "source_commit": "1fde5fe1c117ec0ca671cadc9fb80a862cd7f61c"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "2183c588733d98fdfeca923a931157fb441ff90e"
+  "source_commit": "674f12257ee93e29bface6786936b02b74959984"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "b32643c"
+  "source_commit": "b32643cb9518bd4cccecb4e86f9f622857c631e6"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "79a3e8943d05c4ac192bfa9979d4c4720cd11fec"
+  "source_commit": "9a76fd754a90e8e4dc34894753df9d8aa253a04e"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "e3be44e06cd4b50efb072ef305024c2dea862a92"
+  "source_commit": "756aa00fd1a1dee07dbf17547d1a8f131258bced"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "756aa00fd1a1dee07dbf17547d1a8f131258bced"
+  "source_commit": "83c523a65470425baea6c6f5c88a44b315eb99c1"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "db6afd9beb009c4bdc2ca5d010493fecb85a86d8"
+  "source_commit": "c7730d25887b16c02074bdd690b8c93e956c3f0e"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,0 +1,9 @@
+{
+  "name": "Roam Logbook – 404KSG",
+  "short_description": "Org-style Roam task clocks with a native dashboard, Pomodoro, and task rollups.",
+  "author": "forrestchang, 404KSG",
+  "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
+  "source_url": "https://github.com/404KSG/roam-logbook",
+  "source_repo": "https://github.com/404KSG/roam-logbook.git",
+  "source_commit": "52a1032a3396ce374da50c63a065d9b5125d28cc"
+}

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -1,6 +1,6 @@
 {
   "name": "Roam Logbook – 404KSG",
-  "short_description": "Org-style Roam task clocks with Linear-inspired dashboard panels, paused-session recovery, Pomodoro, and task rollups.",
+  "short_description": "Org-style Roam task clocks with a compact Roam/Linear dashboard, paused-session recovery, Pomodoro, and task rollups.",
   "author": "forrestchang, 404KSG",
   "tags": [
     "productivity",
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "b32643cb9518bd4cccecb4e86f9f622857c631e6"
+  "source_commit": "bd142ba9349a8e717e250599d6d6693f9293cb87"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "9a76fd754a90e8e4dc34894753df9d8aa253a04e"
+  "source_commit": "c2504e75637ee0022c2ba017dedb1c0883e50f64"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "c7730d25887b16c02074bdd690b8c93e956c3f0e"
+  "source_commit": "94228eef06148cf912a0c8eebf8a9e55ebc2d3ef"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "8f68984c8d9ad67a5ee7d25f23f5ab17e41bb787"
+  "source_commit": "db6afd9beb009c4bdc2ca5d010493fecb85a86d8"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "843da3f0ee5736382afcff56cc71494b086934ea"
+  "source_commit": "2d8a188dbc8c8ef5b461830998bd86a002c1dd55"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -5,5 +5,5 @@
   "tags": ["productivity", "time tracking", "pomodoro", "TODO", "logbook"],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "440e1b6a6cab68d3e73bb585c94c8e2f358bf64f"
+  "source_commit": "7f6feab4474162ec5f5254a66833fa2825b2c2bc"
 }

--- a/extensions/404KSG/roam-logbook.json
+++ b/extensions/404KSG/roam-logbook.json
@@ -11,5 +11,5 @@
   ],
   "source_url": "https://github.com/404KSG/roam-logbook",
   "source_repo": "https://github.com/404KSG/roam-logbook.git",
-  "source_commit": "94228eef06148cf912a0c8eebf8a9e55ebc2d3ef"
+  "source_commit": "b32643c"
 }


### PR DESCRIPTION
## Summary

- Renames the canonical source repository to `404KSG/roam-task-tracker` and shortens its public description.
- Starts native right-sidebar navigation immediately for trusted Active Threads, Today, and Dashboard task actions, while queued graph resolution and TODO/DONE validation remain authoritative.
- Caches snapshot-invariant Active Work indexes; 10,001 CLOCK entries across 100 repeated derivations improved from 40.49 ms to 2.41 ms in the focused benchmark.
- Caches Dashboard fixed metrics so one-second ticks update only running Sessions; full history is revisited only on refresh, range changes, or a local-day boundary.
- Aligns the Dashboard header action with the Timing action rail to within 0.5 px.
- Hides visible popover and Dashboard scrollbars while preserving native scrolling and stable width.

## Verification

- Source repository: https://github.com/404KSG/roam-task-tracker
- Source commit: 155fa3c18d07a5eff0275a686c61c344bd939064
- Version: 0.9.0-beta.55
- `npm run check` passed: lint, workflow contract, byte-synchronized bundle, Chromium layout coverage, and 437/437 tests.
- Regression coverage confirms trusted task actions publish sidebar navigation before graph reads, without bypassing authoritative mutation checks.
- Regression coverage confirms Active Work snapshot reuse, Dashboard tick caching, local-day rollover, hidden-but-scrollable surfaces, and action-rail alignment.

## Manual gate

The PR intentionally remains Draft. Beta.55 should be smoke-tested in Roam with the native right sidebar both closed and already open, using rapid task switches plus long Thread/Today lists.