### PR TITLE
Update Drag References native Command reference gesture

### DIFF
--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "52aa2e04b5e7bf9b9682bbf668c175e4a8cd34ee"
+  "source_commit": "443201b9042f83b9633e3130a9f757eafd5a365c"
 }


### PR DESCRIPTION
## Summary

Update Drag References to the latest testing build.

- Plain Drag: Roam native block move.
- Command + Drag: Roam native ((blockUid)) reference drag, with exact ((blockUid)) copied to the clipboard.
- Option + Drag: original block text plus [*](((blockUid))).
- Control + Drag: [*](((blockUid))).
- Shift + Drag: {{embed-path: ((blockUid))}}.

## Validation

- npm test: 50 passed.
- npm run build: passed.
- npm run check: passed.
- git diff --check: passed.

This is intentionally a Draft PR for in-Roam testing before formal review.