### PR TITLE
Add RoamJS Quick Switcher Extension

### DIFF
--- a/extensions/RoamJS/quick-switcher.json
+++ b/extensions/RoamJS/quick-switcher.json
@@ -16,6 +16,6 @@
   ],
   "source_url": "https://github.com/RoamJS/quick-switcher",
   "source_repo": "https://github.com/RoamJS/quick-switcher.git",
-  "source_commit": "6cddf3d23f99655379f4cdd510b7b2879afd765a",
+  "source_commit": "edc6d707804f1c5d6285d9d9b1f65fddc7d5e6b0",
   "stripe_account": "acct_1SvNcDHhjqZussBl"
 }

--- a/extensions/RoamJS/quick-switcher.json
+++ b/extensions/RoamJS/quick-switcher.json
@@ -1,0 +1,21 @@
+{
+  "name": "Quick Switcher",
+  "short_description": "Jump instantly to saved Roam pages and blocks from a fast, searchable switcher or the command palette, with aliases and right-sidebar support.",
+  "author": "RoamJS",
+  "tags": [
+    "quick-switcher",
+    "navigation",
+    "search",
+    "bookmarks",
+    "pages",
+    "blocks",
+    "command-palette",
+    "sidebar",
+    "aliases",
+    "productivity"
+  ],
+  "source_url": "https://github.com/RoamJS/quick-switcher",
+  "source_repo": "https://github.com/RoamJS/quick-switcher.git",
+  "source_commit": "6cddf3d23f99655379f4cdd510b7b2879afd765a",
+  "stripe_account": "acct_1SvNcDHhjqZussBl"
+}


### PR DESCRIPTION
https://www.loom.com/share/ab1792d7740b4d049091098d80eccee7

## Summary

- add Quick Switcher to Roam Depot

Quick Switcher lets users save Roam pages and blocks, find them in a fast searchable dialog, open them in the main window or right sidebar, and optionally expose them as command palette commands.

## Validation

- manifest parses as valid JSON
- pinned source commit exists on public `RoamJS/quick-switcher` `main`
- pinned source builds with zero errors
- all 12 source tests pass
