### PR TITLE
Add Publora extension

### DIFF
--- a/extensions/publora-team/roam-publora.json
+++ b/extensions/publora-team/roam-publora.json
@@ -1,0 +1,9 @@
+{
+  "name": "Publora",
+  "short_description": "Send a block or page to ten social networks: publish now, save a draft, or schedule it.",
+  "author": "Publora",
+  "tags": ["export", "social", "publishing", "scheduling"],
+  "source_url": "https://github.com/publora-team/roam-publora",
+  "source_repo": "https://github.com/publora-team/roam-publora.git",
+  "source_commit": "32494c5f734fadc5b5c7280a348b3eba632d8e79"
+}


### PR DESCRIPTION
Adds Publora, an extension that sends a block or a page to social networks.

**What it does.** Two commands in the palette: send the focused block, or send the open page with its blocks joined in order. A window opens with the accounts the user connected in Publora, the text, and the choice between publishing now, saving a draft, and scheduling for a chosen time. Ten networks are supported: LinkedIn, X, Instagram, Threads, TikTok, YouTube, Facebook, Bluesky, Mastodon and Telegram.

**Account and key.** Publora is a hosted service, so the extension needs an account; the free plan is 15 posts a month with no card. The API key lives in the extension settings and is sent only to `https://api.publora.com` in a request header. The extension reads nothing from the graph beyond the block or page the user chose, and only when the command is run.

**Code.** Plain `extension.js` with the `onload` / `onunload` pair, plus `extension.css`; no build step, so no `build.sh`. Commands are registered through `extensionAPI.ui.commandPalette` and removed in `onunload`, and the settings panel is created through `extensionAPI.settings.panel`.

Source: https://github.com/publora-team/roam-publora
