### PR TITLE
Add Nautilus Log extension

### DIFF
--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -1,0 +1,9 @@
+{
+  "name": "Nautilus Flow",
+  "short_description": "A transparent visual time-blocking planner that dynamically schedules today's tasks and makes overload visible.",
+  "author": "404KSG",
+  "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
+  "source_url": "https://github.com/404KSG/roam-nautilus-flow",
+  "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
+  "source_commit": "ea6f27cfc06b963fb52e1ca6261bef06769ccd54"
+}

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "ea6f27cfc06b963fb52e1ca6261bef06769ccd54"
+  "source_commit": "986283e114b683114f9bfcaf5928274ac6d1537a"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "d39623412f0094ea6cc102cd26d5080a370a6ece"
+  "source_commit": "a0b7228f71e7faf37a43a70340780b4b6f38f150"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "986283e114b683114f9bfcaf5928274ac6d1537a"
+  "source_commit": "3f9103e473af0bdb7d66acd31f0cfde10d743d36"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "c931747decd8541e04923072dfeb872e5dd8f8d5"
+  "source_commit": "79bd52a98e7eafdb276d42c8c9faf6fe1b46e4d8"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "975afbb431dbe06b09221e91f28fff11de30a541"
+  "source_commit": "7fe772eb884341d5c961b017e84c58fe90756bdf"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "3f9103e473af0bdb7d66acd31f0cfde10d743d36"
+  "source_commit": "3d3a51482acd9d438012cdfd6e84c2a852a2afe4"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "a0b7228f71e7faf37a43a70340780b4b6f38f150"
+  "source_commit": "c39f5887ca2685d78d04f1b721878ebd518fc808"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "2648a6c7ce259271f42ed8d298b44e7f59d09a57"
+  "source_commit": "aaa5605fccc2e11346ce317d4ca3a7e916bdb39a"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "73743bd1e94573eef4181a219bd129c2b97c6e66"
+  "source_commit": "46d2e39920b71aae43b3d0a8b96e0c2b1fad49e8"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "71a9b48599ef578c3b679d39d5142986dd779b62"
+  "source_commit": "ffc80c94cf9bb004434aeead22e0456296066f85"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "ffc80c94cf9bb004434aeead22e0456296066f85"
+  "source_commit": "975afbb431dbe06b09221e91f28fff11de30a541"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "3d3a51482acd9d438012cdfd6e84c2a852a2afe4"
+  "source_commit": "1fa6cb1d3817e93157dac2e53ed0726a8e7a6a5d"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "79bd52a98e7eafdb276d42c8c9faf6fe1b46e4d8"
+  "source_commit": "73743bd1e94573eef4181a219bd129c2b97c6e66"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "aaa5605fccc2e11346ce317d4ca3a7e916bdb39a"
+  "source_commit": "490610f506c124ceda99f1f11d3e4388ce2b6cee"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "46d2e39920b71aae43b3d0a8b96e0c2b1fad49e8"
+  "source_commit": "a9a46f18b1cdc9cb2f9d3ca0f32570f6a0fdcac3"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "d8276df1d24749f8b8ba09dd2cf2c6ddfd84298c"
+  "source_commit": "2648a6c7ce259271f42ed8d298b44e7f59d09a57"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "2bf8a0cad86da481ec5a8df267b6d6cdc9f29fef"
+  "source_commit": "1a22d4b49da94b84292e1c22b8cd73b3df9b6c9c"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "7fe772eb884341d5c961b017e84c58fe90756bdf"
+  "source_commit": "c7e662dbbbfb0827105cbe748e0e39cb1bea110f"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "a0be81580760e90a8462e8e794d9d4692e239f26"
+  "source_commit": "c931747decd8541e04923072dfeb872e5dd8f8d5"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "1a22d4b49da94b84292e1c22b8cd73b3df9b6c9c"
+  "source_commit": "71a9b48599ef578c3b679d39d5142986dd779b62"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "fd6240d3753df5c7ff59b50e8ca92768cb24137c"
+  "source_commit": "ba2943a6d80018f20ca6e4fcb1576aec48965fed"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "c7e662dbbbfb0827105cbe748e0e39cb1bea110f"
+  "source_commit": "fd6240d3753df5c7ff59b50e8ca92768cb24137c"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "ba2943a6d80018f20ca6e4fcb1576aec48965fed"
+  "source_commit": "d39623412f0094ea6cc102cd26d5080a370a6ece"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "c39f5887ca2685d78d04f1b721878ebd518fc808"
+  "source_commit": "d8276df1d24749f8b8ba09dd2cf2c6ddfd84298c"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "1fa6cb1d3817e93157dac2e53ed0726a8e7a6a5d"
+  "source_commit": "a0be81580760e90a8462e8e794d9d4692e239f26"
 }

--- a/extensions/404KSG/roam-nautilus-flow.json
+++ b/extensions/404KSG/roam-nautilus-flow.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-flow",
   "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "a9a46f18b1cdc9cb2f9d3ca0f32570f6a0fdcac3"
+  "source_commit": "2bf8a0cad86da481ec5a8df267b6d6cdc9f29fef"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "66624b53b8164e52f337ded46c6bd2a3d682e68a"
+  "source_commit": "ab0bdddb340c716c25effe35b02c246b10f3d532"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "71f5369964d499748e01fe03fe58219d530ba74f"
+  "source_commit": "76fefe901d0925b8769539ffe8241dd7f230100d"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "8697ecebe09984ef77b9297f6490777dba30ea1a"
+  "source_commit": "c67fc2e7ed1ed77a11fa14f354ac5399a5ef79d1"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "60d776fd2e11f012129fce9b65f982b1fbb1202e"
+  "source_commit": "c45bfe501d3a66f842d26238dba3f7115bc500b7"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "c45bfe501d3a66f842d26238dba3f7115bc500b7"
+  "source_commit": "f55a5756f3fc5358264c0adad085154cdbe57171"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "ab0bdddb340c716c25effe35b02c246b10f3d532"
+  "source_commit": "915e9437937dca63fb8a27834d417f716aafc14b"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6cafb3f5fb2546ecc3527aa8e7e4b1203d10d6ab"
+  "source_commit": "db94b3ebf7cdb9afd3add2cb3f9e495b757207cd"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "b29fa052ec7dc80f435c3584f5bba2ef29a45a0e"
+  "source_commit": "66624b53b8164e52f337ded46c6bd2a3d682e68a"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "9d60fae38729ab5e56bdc562edcb582c44b3303a"
+  "source_commit": "b29fa052ec7dc80f435c3584f5bba2ef29a45a0e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "eb29d8990638ba9661019d343c921a5a6acce971"
+  "source_commit": "976506d35528733998bf3a4142a26241a882f89d"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "c67fc2e7ed1ed77a11fa14f354ac5399a5ef79d1"
+  "source_commit": "5568cad621c9ef02c9dd7ebfe11e1d1745d39b00"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "ad20d9ff02fc68e14765ffd92f80c8a07f1082a7"
+  "source_commit": "4986b02c605650aef0517b41477a9d2252b1862c"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "915e9437937dca63fb8a27834d417f716aafc14b"
+  "source_commit": "71f5369964d499748e01fe03fe58219d530ba74f"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "db94b3ebf7cdb9afd3add2cb3f9e495b757207cd"
+  "source_commit": "ad20d9ff02fc68e14765ffd92f80c8a07f1082a7"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "5568cad621c9ef02c9dd7ebfe11e1d1745d39b00"
+  "source_commit": "60d776fd2e11f012129fce9b65f982b1fbb1202e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -1,9 +1,9 @@
 {
   "name": "Nautilus Log",
-  "short_description": "A transparent visual day planner with optional CLOCK timing, task switching, and overload visibility.",
+  "short_description": "A transparent visual day planner with optional CLOCK timing, task switching, overload visibility, and a lightweight daily review.",
   "author": "404KSG",
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4986b02c605650aef0517b41477a9d2252b1862c"
+  "source_commit": "857b91a8a9641ccf2d59046e48b48f64d367bf90"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "c4afe07c949fd9c1dcdd98b18e71e4d5fc2df47d"
+  "source_commit": "f5cb32ef912964c0def94ebfe1ac0b13ec7e152c"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -1,9 +1,9 @@
 {
   "name": "Nautilus Log",
-  "short_description": "A transparent visual time-blocking planner that dynamically schedules today's tasks and makes overload visible.",
+  "short_description": "A transparent visual day planner with optional CLOCK timing, task switching, and overload visibility.",
   "author": "404KSG",
-  "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
+  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "976506d35528733998bf3a4142a26241a882f89d"
+  "source_commit": "8697ecebe09984ef77b9297f6490777dba30ea1a"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "857b91a8a9641ccf2d59046e48b48f64d367bf90"
+  "source_commit": "9d60fae38729ab5e56bdc562edcb582c44b3303a"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f55a5756f3fc5358264c0adad085154cdbe57171"
+  "source_commit": "c0325fe2c189bda7b5f48123e9dda2759b9ebfda"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "76fefe901d0925b8769539ffe8241dd7f230100d"
+  "source_commit": "c4afe07c949fd9c1dcdd98b18e71e4d5fc2df47d"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -1,9 +1,9 @@
 {
-  "name": "Nautilus Flow",
+  "name": "Nautilus Log",
   "short_description": "A transparent visual time-blocking planner that dynamically schedules today's tasks and makes overload visible.",
   "author": "404KSG",
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
-  "source_url": "https://github.com/404KSG/roam-nautilus-flow",
-  "source_repo": "https://github.com/404KSG/roam-nautilus-flow.git",
-  "source_commit": "490610f506c124ceda99f1f11d3e4388ce2b6cee"
+  "source_url": "https://github.com/404KSG/roam-nautilus-log",
+  "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
+  "source_commit": "616cc069cf294bb5c10a629ba6e57206f5cbdd32"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "tasks", "planning", "productivity", "visualization"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "616cc069cf294bb5c10a629ba6e57206f5cbdd32"
+  "source_commit": "eb29d8990638ba9661019d343c921a5a6acce971"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "c0325fe2c189bda7b5f48123e9dda2759b9ebfda"
+  "source_commit": "6cafb3f5fb2546ecc3527aa8e7e4b1203d10d6ab"
 }


### PR DESCRIPTION
## Summary

Adds Nautilus Log, a transparent visual time-blocking planner with an optional CLOCK-based execution layer for Roam Research.

- Dynamically places unfinished tasks into remaining free time around fixed events
- Displays available time, event occupancy, planned demand, remaining capacity, overload, fragmented free time, and overflow tasks
- Supports configurable chart boundaries, with a 05:00 start and 21:00 end by default
- Defaults fresh and upgraded preview installs to English; Chinese remains available through Language settings
- Adds responsive layout, per-instance collapse, past-time states, label truncation, collision handling, and current-task emphasis
- Adds optional Timing, flat Plan, and lightweight daily Review views with CLOCK switching, Pomodoro, completion, deletion, and Planned/Actual comparison
- Keeps render, template, runtime, and CSS identifiers isolated under Nautilus Log
- Makes Clock In follow the native Shift+Click hot path: synchronous window reads and addWindow remain in the original click stack, with no wait for the sidebar-open animation
- Keeps a deduplicated wait/retry fallback for older Roam hosts
- Confirms a closed CLOCK by its known block UID instead of inserting another graph-wide LOGBOOK scan during task switching
- Avoids rebuilding the execution list for the transient working state and prevents unchanged install polling from invalidating every Nautilus chart
- Rebuilds the bilingual README around the product advantages, three-layer time-management model, daily workflow, metrics, Actual tracking, Review, settings, and data-safety boundaries

Give every minute a job. / 给每一分钟分配一份工作。

## Source

https://github.com/404KSG/roam-nautilus-log

Source commit: f5cb32ef912964c0def94ebfe1ac0b13ec7e152c

## Verification

- npm test: 86 tests passed
- production webpack build completed successfully
- native sidebar ordering, no-open-wait, same-click-stack, fallback retry, and reduced CLOCK-query paths are regression tested
- README claims were checked against current defaults, scheduler, capacity metrics, CLOCK rules, and render-suppression behavior
- JSON validation and git diff checks passed
- fixed-base review completed against upstream/main with no remaining blocking findings

This PR remains a draft for Roam Depot shorthand testing.