### PR TITLE
Add Nautilus Log extension

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "97f74c3c65b146cc0523c07c2e67690461373668"
+  "source_commit": "4e33ed2b87745643906d1e76f11cd16850203523"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4143503af7b593edc401bdea338cf21be3576260"
+  "source_commit": "c7b7997a957b331b56ef7f64763a9007c1d124b0"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3d9f72904aec5ae339128fc725ef3b337f8629d8"
+  "source_commit": "4143503af7b593edc401bdea338cf21be3576260"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "69c522610afa7a5ecd685d00a9200a668cb8f292"
+  "source_commit": "3d9f72904aec5ae339128fc725ef3b337f8629d8"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "9440a4115c5d4a7ae821c7cdfb9f7dc2fcba8166"
+  "source_commit": "cb5239cbf765c8c9175155293bc233cd42344aa5"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "ef33f63c62459b5d4d60e40ef2f0025701baf113"
+  "source_commit": "d89bfc4786933458b185a650e5869c4a9cb48ee9"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f5cb32ef912964c0def94ebfe1ac0b13ec7e152c"
+  "source_commit": "69c522610afa7a5ecd685d00a9200a668cb8f292"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -1,0 +1,9 @@
+{
+  "name": "Nautilus Log",
+  "short_description": "A transparent visual day planner with optional CLOCK timing, task switching, overload visibility, and a lightweight daily review.",
+  "author": "404KSG",
+  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
+  "source_url": "https://github.com/404KSG/roam-nautilus-log",
+  "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
+  "source_commit": "f5cb32ef912964c0def94ebfe1ac0b13ec7e152c"
+}

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "c7b7997a957b331b56ef7f64763a9007c1d124b0"
+  "source_commit": "97f74c3c65b146cc0523c07c2e67690461373668"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "32f80ac00a6d80c9969c34c5cb0191a029da1a8e"
+  "source_commit": "9440a4115c5d4a7ae821c7cdfb9f7dc2fcba8166"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6c2f3c6d5ad4a30b3918b93936b10cd34e42fd6f"
+  "source_commit": "ef33f63c62459b5d4d60e40ef2f0025701baf113"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "cb5239cbf765c8c9175155293bc233cd42344aa5"
+  "source_commit": "6c2f3c6d5ad4a30b3918b93936b10cd34e42fd6f"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4e33ed2b87745643906d1e76f11cd16850203523"
+  "source_commit": "32f80ac00a6d80c9969c34c5cb0191a029da1a8e"
 }


### PR DESCRIPTION
## Summary

Adds Nautilus Log, a transparent visual day planner for Roam Research.

- Places flexible tasks into the remaining gaps around fixed events
- Keeps overload, fragmented capacity, and unscheduled work visible
- Uses deterministic Roam block order and user-written estimates
- Supports configurable 05:00–24:00 chart boundaries
- Adds responsive spiral rendering, collision-safe labels, past-time states, and a compact sidebar view
- Offers optional CLOCK-based Timing, Plan, and daily Review views
- Shows Available capacity plus Remaining, Overload, or No fitting slot in the execution panel
- Separates Plan into Scheduled today and collapsible Unscheduled today sections
- Keeps Actual Time Tracking disabled by default and prevents competing CLOCK writers
- Uses isolated render, runtime, template, and CSS identifiers

> Give every minute a job.

## Source

https://github.com/404KSG/roam-nautilus-log

Source commit: 97f74c3c65b146cc0523c07c2e67690461373668

## Verification

- npm test: 91 tests passed
- production webpack build completed successfully
- JSON validation and diff checks passed
- execution-panel capacity reuses the cached Primary Plan and performs no extra graph read

The README includes a concise product overview, English and Chinese guides, a current product screenshot, and attribution links for Nautilus, Nautilus Enhanced, Roam Logbook, and the YNAB Method.