### PR TITLE
Fix README media in Depot-rendered extensions

### DIFF
--- a/extensions/404KSG/contribution-graph.json
+++ b/extensions/404KSG/contribution-graph.json
@@ -5,5 +5,5 @@
   "tags": ["analytics", "activity", "history", "heatmap", "productivity"],
   "source_url": "https://github.com/404KSG/contribution-graph",
   "source_repo": "https://github.com/404KSG/contribution-graph.git",
-  "source_commit": "3686d356e14c8ee0924ceb7b7c000040730e25fc"
+  "source_commit": "b12e20da83b03e00faa57542408de516f91d1945"
 }

--- a/extensions/404KSG/roam-drag-references.json
+++ b/extensions/404KSG/roam-drag-references.json
@@ -5,5 +5,5 @@
   "tags": ["drag-and-drop", "references", "blocks", "clipboard", "productivity"],
   "source_url": "https://github.com/404KSG/roam-drag-references",
   "source_repo": "https://github.com/404KSG/roam-drag-references.git",
-  "source_commit": "52aa2e04b5e7bf9b9682bbf668c175e4a8cd34ee"
+  "source_commit": "a8709da8fde7b9d3c9433eeb4d37a68d21c28f0d"
 }

--- a/extensions/404KSG/roam-remove-tag.json
+++ b/extensions/404KSG/roam-remove-tag.json
@@ -5,5 +5,5 @@
   "tags": ["tags", "blocks", "editing", "productivity"],
   "source_url": "https://github.com/404KSG/roam-remove-tag",
   "source_repo": "https://github.com/404KSG/roam-remove-tag.git",
-  "source_commit": "ee3ee5ea1a0c61ada0863a521bc1763092ec3373"
+  "source_commit": "6c1ebfb4c4ef6e3c65dbd29f404bfb71c6083eab"
 }


### PR DESCRIPTION
Updates the pinned source commits for Contribution Graph, Drag References, and Roam Remove Tag.

Each README now uses absolute HTTPS media URLs so images and demo links resolve when Roam Depot renders the README outside GitHub. Repository tests also guard against relative media paths.