### PR TITLE
Update Nautilus Log to v1.0.2

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f525c4fb1a374a1a858c796368d08e163cec5e86"
+  "source_commit": "677b39811a17d251c39542869a4331748d53b9e9"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "33e9fa0d5dd50496cad04f3ec22007cc69213b9b"
+  "source_commit": "3b8f0365e36c30231bbd393c2c90be16e0f836fa"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "9e1e952715b295e6bbdfe854f69036fe7bfa09db"
+  "source_commit": "4a9d4506de76e3e569ae036df54fefec0f7ef87f"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7e13740f56deba57d12d4f2eedcd491a96022219"
+  "source_commit": "62b924c49502c0d8f8b229bbb2c75ba6becd31a3"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "77bc39748277d866bd5f09f695239105ac2a1a7b"
+  "source_commit": "7bf19a1d482678d1f22d08bb08307b98ce2e5fd4"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "5b87a6a38e48f37502e07530e28626513faf35cc"
+  "source_commit": "f525c4fb1a374a1a858c796368d08e163cec5e86"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "62d0fe892f72062ff4b41558562b8d7a62c244bd"
+  "source_commit": "6e1fe568067ed304fddcdd1267941f177df33264"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "973a041aa2f59f3b05bf31db8187efbfea07017a"
+  "source_commit": "9e1e952715b295e6bbdfe854f69036fe7bfa09db"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "62b924c49502c0d8f8b229bbb2c75ba6becd31a3"
+  "source_commit": "3570abea91fb38b41a71540f9f2fdfcd1f238436"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6e1fe568067ed304fddcdd1267941f177df33264"
+  "source_commit": "5b87a6a38e48f37502e07530e28626513faf35cc"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "703d13c860db744938c0420fd4967877270541ec"
+  "source_commit": "7e13740f56deba57d12d4f2eedcd491a96022219"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3b8f0365e36c30231bbd393c2c90be16e0f836fa"
+  "source_commit": "77bc39748277d866bd5f09f695239105ac2a1a7b"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f6daa1890079f58339421e44a7d12ebd947c9ddf"
+  "source_commit": "62d0fe892f72062ff4b41558562b8d7a62c244bd"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "677b39811a17d251c39542869a4331748d53b9e9"
+  "source_commit": "3d24b36cb493da85afdb87c04664093b55cb8368"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "b1a76710fad19df8b24d60ff0093792d770c51ab"
+  "source_commit": "973a041aa2f59f3b05bf31db8187efbfea07017a"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "8ffb01d6929aa745ccc97e990adb300c3a11a1a0"
+  "source_commit": "5254f023992a91e664629f604e28d9d8f6e70091"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "5254f023992a91e664629f604e28d9d8f6e70091"
+  "source_commit": "703d13c860db744938c0420fd4967877270541ec"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "d89bfc4786933458b185a650e5869c4a9cb48ee9"
+  "source_commit": "b1a76710fad19df8b24d60ff0093792d770c51ab"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "64420809cf5b59e5e0853a73a8ccb0d7585dc3e9"
+  "source_commit": "8ffb01d6929aa745ccc97e990adb300c3a11a1a0"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3d24b36cb493da85afdb87c04664093b55cb8368"
+  "source_commit": "d45057cabeb5aca11b8ec27946d77565996f58a5"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3570abea91fb38b41a71540f9f2fdfcd1f238436"
+  "source_commit": "f6daa1890079f58339421e44a7d12ebd947c9ddf"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "d45057cabeb5aca11b8ec27946d77565996f58a5"
+  "source_commit": "33e9fa0d5dd50496cad04f3ec22007cc69213b9b"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4a9d4506de76e3e569ae036df54fefec0f7ef87f"
+  "source_commit": "64420809cf5b59e5e0853a73a8ccb0d7585dc3e9"
 }


### PR DESCRIPTION
## Summary

- preserve historical Daily Notes as fully elapsed with hatched unrecorded time
- keep Execution Layer capacity aligned with direct block-reference tasks
- add a standalone count-up POMO that does not write CLOCK or affect Planned, Actual, Review, or the spiral
- support global and overnight chart windows
- identify the Primary Plan by the stable Nautilus renderer, so custom or empty Component Prefix values keep Timing, Plan, and Review working
- reject unrelated roam/render blocks that only contain the display label
- lock this Draft preview to source commit d45057cabeb5aca11b8ec27946d77565996f58a5

## Verification

- npm test: 125 tests passed
- production webpack build passed
- git diff --check passed
- manifest JSON validation passed