### PR TITLE
Update Nautilus Log

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "5464e9da71ac1de06623826fa2cf4bd7434c76b2"
+  "source_commit": "7850e58b63a34eebfc9d389c7bd681c083acb987"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "14e8d0704bbf5bf089875302fef9b4eb44dc64e3"
+  "source_commit": "37bf8622a3615257dc9487f0e5dddc5ea423ddf5"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "888e59ad7dc01e38190ae15936daf94c385e80e6"
+  "source_commit": "5cc301d1e3bce50bd800be8e8676b5d2679070cb"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "e4b922e7c649d70edffdb618d9987a492b548594"
+  "source_commit": "8913ad19a12163cbdc455d7501fa41aed23582f8"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7030f3ae1b160290f1db8dc7e71cbfad1409a268"
+  "source_commit": "08892f948c63e4cacd3fc1cc100a600dd38c21f8"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "8913ad19a12163cbdc455d7501fa41aed23582f8"
+  "source_commit": "86b97c0ea1cf5c3d08281caad33af0e86e084869"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "30d9b774aed1c654408dcec698b551c914174d86"
+  "source_commit": "0f3fc2884059ceaf2dc75019660bb7505313e742"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "ee1ba1241cfebf00e4572057e6774158e8f6eeb2"
+  "source_commit": "4f9c4c6b1f5d57315ca620cd7c2898a8d59ccc13"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "a2e060282f68e5996d1291a0e6f9ef126b344033"
+  "source_commit": "5464e9da71ac1de06623826fa2cf4bd7434c76b2"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7bf19a1d482678d1f22d08bb08307b98ce2e5fd4"
+  "source_commit": "7a7ae216ada4fcf8adf6e374951bcfd9c3ed8cda"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "d807ea448e17c6cc5b8c4dcc8d534e0a753e3118"
+  "source_commit": "e4b922e7c649d70edffdb618d9987a492b548594"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "a79515d5f7e36851d043e7a82ca705c1cb2a7fd8"
+  "source_commit": "30d9b774aed1c654408dcec698b551c914174d86"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7a7ae216ada4fcf8adf6e374951bcfd9c3ed8cda"
+  "source_commit": "e0805248da740aff727a66416cc1b3c3ec644ece"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "2a8b5251a3bf1690c4bec11b526745b4c80bc816"
+  "source_commit": "eeabe400d85a62dc80e46cfb424b886500dfea83"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7850e58b63a34eebfc9d389c7bd681c083acb987"
+  "source_commit": "d807ea448e17c6cc5b8c4dcc8d534e0a753e3118"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "5cc301d1e3bce50bd800be8e8676b5d2679070cb"
+  "source_commit": "5810fcf0d0d783aef5ec4bd331d3a15a4ff6e7ae"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "eeabe400d85a62dc80e46cfb424b886500dfea83"
+  "source_commit": "f981a292ce82a3f5deb7a202236fece7c27b104f"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "bc60f9bfc7b59c3025e4f6ea544809b8f720f2c1"
+  "source_commit": "2a8b5251a3bf1690c4bec11b526745b4c80bc816"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "37bf8622a3615257dc9487f0e5dddc5ea423ddf5"
+  "source_commit": "a79515d5f7e36851d043e7a82ca705c1cb2a7fd8"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "e89a114afd6baa838149b78232ff8b0e7ef47f1c"
+  "source_commit": "ee1ba1241cfebf00e4572057e6774158e8f6eeb2"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "974422d12e08b59c944da5716161cecb228874c9"
+  "source_commit": "7722b60ccfa5ff8dbaccfb88b86c5cb8cccf0822"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "1bf566de45685ff66e197211216beb89ed441f07"
+  "source_commit": "f4e6f3a571fada9931a84ea39c4f8f7216add691"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f981a292ce82a3f5deb7a202236fece7c27b104f"
+  "source_commit": "a2e060282f68e5996d1291a0e6f9ef126b344033"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "e0805248da740aff727a66416cc1b3c3ec644ece"
+  "source_commit": "bc60f9bfc7b59c3025e4f6ea544809b8f720f2c1"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "5810fcf0d0d783aef5ec4bd331d3a15a4ff6e7ae"
+  "source_commit": "7030f3ae1b160290f1db8dc7e71cbfad1409a268"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7722b60ccfa5ff8dbaccfb88b86c5cb8cccf0822"
+  "source_commit": "e89a114afd6baa838149b78232ff8b0e7ef47f1c"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4f9c4c6b1f5d57315ca620cd7c2898a8d59ccc13"
+  "source_commit": "1bf566de45685ff66e197211216beb89ed441f07"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f4e6f3a571fada9931a84ea39c4f8f7216add691"
+  "source_commit": "888e59ad7dc01e38190ae15936daf94c385e80e6"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "86b97c0ea1cf5c3d08281caad33af0e86e084869"
+  "source_commit": "974422d12e08b59c944da5716161cecb228874c9"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "08892f948c63e4cacd3fc1cc100a600dd38c21f8"
+  "source_commit": "14e8d0704bbf5bf089875302fef9b4eb44dc64e3"
 }


### PR DESCRIPTION
## Summary

- update Nautilus Log from Marketplace source commit `7bf19a1d482678d1f22d08bb08307b98ce2e5fd4` to `0f3fc2884059ceaf2dc75019660bb7505313e742`
- keep one-second Timing updates graph-free and reuse the shared Primary Plan Pull
- add the Roam-native Tidy Primary Plan command for user-defined Hotkeys
- add semantic Left and Free capacity tones without new graph reads, observers, or timers
- isolate chart collapse preferences by render surface
  - the main view and right sidebar no longer overwrite one shared collapse state
  - locating the Primary Plan remains navigation-only and cannot fold an expanded chart
  - legacy ambiguous collapse state is ignored once and each surface defaults to expanded

## Validation

- `npm test` — 165 tests passed
- production webpack build passed
- Roam SCI delimiter contract passed
- `node --check extension.js` passed
- Depot manifest diff changes only `source_commit`

Ready for Roam Depot review.