### PR TITLE
Update Save Scrollbar Position

### DIFF
--- a/extensions/studyduck/roam-save-scrollbar-position.json
+++ b/extensions/studyduck/roam-save-scrollbar-position.json
@@ -5,5 +5,5 @@
   "tags": ["scrollbar"],
   "source_url": "https://github.com/studyduck/roam-save-scrollbar-position",
   "source_repo": "https://github.com/studyduck/roam-save-scrollbar-position.git",
-  "source_commit": "f0c1651c6358bc9aa4268115a3a9c051c694540e"
+  "source_commit": "50ff7e95090878c90ab1459abfe31fb594fc7646"
 }

--- a/extensions/studyduck/roam-show-github-star.json
+++ b/extensions/studyduck/roam-show-github-star.json
@@ -8,5 +8,5 @@
   ],
   "source_url": "https://github.com/studyduck/roam-show-github-star",
   "source_repo": "https://github.com/studyduck/roam-show-github-star.git",
-  "source_commit": "b19619aa1297d22653ca1705a4acba80897c9cdd"
+  "source_commit": "413763b1db585f735f0f36677e4782b91ba26076"
 }


### PR DESCRIPTION
Removed scroll position saving and restoration for regular Pages to avoid duplicating Roam’s native behavior. Daily Notes and All Pages remain supported.
Improved route-change and extension lifecycle handling by cancelling stale tasks, properly detaching DOM listeners, and supporting empty views.