### PR TITLE
Update Nautilus Log: optional Google Calendar sync

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "8ab529e9291a5ed1f2d7da0f776ef4c803b5db6e"
+  "source_commit": "3f92e8bc6bf448de51af80eddfb1b5ce770191a5"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "9718dfd9e2ba5c5175fdfd55c964ab7d2cef1815"
+  "source_commit": "528a7df85305f1ebf6c0de8dbfa32d71dc288fcc"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "528a7df85305f1ebf6c0de8dbfa32d71dc288fcc"
+  "source_commit": "23b069812aa76d33d1c9806e74d1571ba4956950"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "a44294f2ed648ae3860ae828856b2a76d8ee91f2"
+  "source_commit": "6bedc8d05eaa07f99ac61c82e21798e942e5a861"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f4b713ea946a592b7e712deb620ba319c25289d4"
+  "source_commit": "9c790bb33b49da56e4a0b9b2b16aabf0bcd871ba"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f5fa92b89c179785f0ea4e9657c0a966abf30a9e"
+  "source_commit": "f4b713ea946a592b7e712deb620ba319c25289d4"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -1,9 +1,9 @@
 {
   "name": "Nautilus Log",
-  "short_description": "A transparent visual day planner with optional CLOCK timing, task switching, overload visibility, and a lightweight daily review.",
+  "short_description": "A transparent visual day planner with optional Google Calendar sync, CLOCK timing, overload visibility, and daily review.",
   "author": "404KSG",
-  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
+  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7bf19a1d482678d1f22d08bb08307b98ce2e5fd4"
+  "source_commit": "a44294f2ed648ae3860ae828856b2a76d8ee91f2"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "c8d0d6053fbff26f89c476426e461ecbde75834e"
+  "source_commit": "3242c7da99c8da6bd54c9599d3be772b56e955e8"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "8ff82ede886c96dac1d16cb1678d9b5c589479b4"
+  "source_commit": "c8d0d6053fbff26f89c476426e461ecbde75834e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3f92e8bc6bf448de51af80eddfb1b5ce770191a5"
+  "source_commit": "a6dcd6e5966b05d62613a3cc2592ae28a2707f97"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6bedc8d05eaa07f99ac61c82e21798e942e5a861"
+  "source_commit": "f5fa92b89c179785f0ea4e9657c0a966abf30a9e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4996542bb74d2adbd7de136d19e59aa680ab7a25"
+  "source_commit": "69ab17916c4d74a6fa2cfebb4895d6e42772df33"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "69ab17916c4d74a6fa2cfebb4895d6e42772df33"
+  "source_commit": "8ff82ede886c96dac1d16cb1678d9b5c589479b4"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "9c790bb33b49da56e4a0b9b2b16aabf0bcd871ba"
+  "source_commit": "7fbc5bb70f44e7a37691719bc2d3f15850cddfc7"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "a6dcd6e5966b05d62613a3cc2592ae28a2707f97"
+  "source_commit": "4996542bb74d2adbd7de136d19e59aa680ab7a25"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7fbc5bb70f44e7a37691719bc2d3f15850cddfc7"
+  "source_commit": "8ab529e9291a5ed1f2d7da0f776ef4c803b5db6e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3242c7da99c8da6bd54c9599d3be772b56e955e8"
+  "source_commit": "9718dfd9e2ba5c5175fdfd55c964ab7d2cef1815"
 }


### PR DESCRIPTION
## Summary

- supersedes #1434 and carries its Nautilus Log updates forward from the current Depot `main`
- adds optional, read-only Google Calendar sync for the exact Nautilus Plan and configured chart window represented by the clicked component
- uses the native Blueprint Calendar glyph; normal click preserves local Roam edits and Option/Alt-click force-refreshes only Google-managed strings
- imports a compact block subtree with source links, optional location, and a shortened plain-text description
- keeps Google access opt-in and manual: no Calendar polling, no background event reads, and no developer fields for users
- bumps Nautilus Log to 1.1.0 and documents OAuth, privacy, merge behavior, and safety boundaries

## Authentication

Nautilus Log uses Google Identity Services' recommended popup authorization-code model. The one-time code returns only to the callback running in the initiating Roam origin, then a small Nautilus service exchanges it for a persistent connection. The extension stores only an opaque connection ID and secret; refresh tokens remain encrypted in the service's D1 database and access tokens remain in memory.

Users click once, choose an account, and normally stay connected after Roam reloads. They do not create or paste a Google OAuth Client ID. Temporary Google failures retain the connection; revoked credentials require consent again. Disabling the feature revokes and deletes the connection when possible.

Calendar event data is fetched directly from Google by the Roam client and never passes through the authorization service. See the source repository's `PRIVACY.md` and `docs/google-calendar-sync.md`.

## Verification

- `npm test` — 192 tests passed
- local D1 migration applied successfully in an isolated temporary store; cleanup verified
- security regressions cover origin-bound code exchange, CORS/custom-header enforcement, encrypted refresh tokens, opaque connection authentication, unload cancellation, startup/click races, transient 429/5xx preservation, invalid-grant cleanup, and disconnect failure
- source commit: `6bedc8d05eaa07f99ac61c82e21798e942e5a861`

## Draft deployment gate

Keep this PR in Draft until the production Google OAuth application and Cloudflare Worker/D1 service are provisioned, the custom domain is healthy, and real-account authorization, reload restoration, sync, and disconnect pass in both browser Roam and Roam Desktop.
