### PR TITLE
Update Nautilus Log with optional Google Calendar sync

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "888ca24e7897652cd1ecbbe2b9aef9ff5c6f9cdc"
+  "source_commit": "bd55071ed3316d152bb13b12dd972d2ec604aaf3"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "8ab529e9291a5ed1f2d7da0f776ef4c803b5db6e"
+  "source_commit": "3f92e8bc6bf448de51af80eddfb1b5ce770191a5"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "9718dfd9e2ba5c5175fdfd55c964ab7d2cef1815"
+  "source_commit": "528a7df85305f1ebf6c0de8dbfa32d71dc288fcc"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "528a7df85305f1ebf6c0de8dbfa32d71dc288fcc"
+  "source_commit": "23b069812aa76d33d1c9806e74d1571ba4956950"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "bd55071ed3316d152bb13b12dd972d2ec604aaf3"
+  "source_commit": "a96f45152e3db28a3c7ae6343fc14ddf170f85b8"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "a44294f2ed648ae3860ae828856b2a76d8ee91f2"
+  "source_commit": "6bedc8d05eaa07f99ac61c82e21798e942e5a861"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f4b713ea946a592b7e712deb620ba319c25289d4"
+  "source_commit": "9c790bb33b49da56e4a0b9b2b16aabf0bcd871ba"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3079df8211ee2bba3bd5b9f3001d23be2004bbb3"
+  "source_commit": "b18548ee22e14d7362ccdc250c0355d981584bcf"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f5fa92b89c179785f0ea4e9657c0a966abf30a9e"
+  "source_commit": "f4b713ea946a592b7e712deb620ba319c25289d4"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "23b069812aa76d33d1c9806e74d1571ba4956950"
+  "source_commit": "888ca24e7897652cd1ecbbe2b9aef9ff5c6f9cdc"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -1,9 +1,9 @@
 {
   "name": "Nautilus Log",
-  "short_description": "A transparent visual day planner with optional CLOCK timing, task switching, overload visibility, and a lightweight daily review.",
+  "short_description": "A transparent visual day planner with optional Google Calendar sync, CLOCK timing, overload visibility, and daily review.",
   "author": "404KSG",
-  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
+  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7bf19a1d482678d1f22d08bb08307b98ce2e5fd4"
+  "source_commit": "a44294f2ed648ae3860ae828856b2a76d8ee91f2"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "c8d0d6053fbff26f89c476426e461ecbde75834e"
+  "source_commit": "3242c7da99c8da6bd54c9599d3be772b56e955e8"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "8ff82ede886c96dac1d16cb1678d9b5c589479b4"
+  "source_commit": "c8d0d6053fbff26f89c476426e461ecbde75834e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4b0977e3d16d134b9a4b45ca4b4c849dbc88173f"
+  "source_commit": "26ed3c8528bbb44e18ee6626cc3ecdc4b565583f"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "59e55a17615e26a90c991bb741610bb28472daf7"
+  "source_commit": "3079df8211ee2bba3bd5b9f3001d23be2004bbb3"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3f92e8bc6bf448de51af80eddfb1b5ce770191a5"
+  "source_commit": "a6dcd6e5966b05d62613a3cc2592ae28a2707f97"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6bedc8d05eaa07f99ac61c82e21798e942e5a861"
+  "source_commit": "f5fa92b89c179785f0ea4e9657c0a966abf30a9e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4996542bb74d2adbd7de136d19e59aa680ab7a25"
+  "source_commit": "69ab17916c4d74a6fa2cfebb4895d6e42772df33"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "69ab17916c4d74a6fa2cfebb4895d6e42772df33"
+  "source_commit": "8ff82ede886c96dac1d16cb1678d9b5c589479b4"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "9c790bb33b49da56e4a0b9b2b16aabf0bcd871ba"
+  "source_commit": "7fbc5bb70f44e7a37691719bc2d3f15850cddfc7"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "a96f45152e3db28a3c7ae6343fc14ddf170f85b8"
+  "source_commit": "4b0977e3d16d134b9a4b45ca4b4c849dbc88173f"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "a6dcd6e5966b05d62613a3cc2592ae28a2707f97"
+  "source_commit": "4996542bb74d2adbd7de136d19e59aa680ab7a25"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7fbc5bb70f44e7a37691719bc2d3f15850cddfc7"
+  "source_commit": "8ab529e9291a5ed1f2d7da0f776ef4c803b5db6e"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "26ed3c8528bbb44e18ee6626cc3ecdc4b565583f"
+  "source_commit": "59e55a17615e26a90c991bb741610bb28472daf7"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3242c7da99c8da6bd54c9599d3be772b56e955e8"
+  "source_commit": "9718dfd9e2ba5c5175fdfd55c964ab7d2cef1815"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "b18548ee22e14d7362ccdc250c0355d981584bcf"
+  "source_commit": "772286892cada37ca5a1bb121655ba6bcec57815"
 }


### PR DESCRIPTION
## Summary

- adds optional read-only Google Calendar and Google Tasks sync
- uses a hosted OAuth connection with persistent authorization and account-aware event links
- keeps local edits safe, supports explicit force refresh, and records Calendar provenance in Roam
- refines Calendar feedback, hover behavior, control order, and settings presentation
- restores the exact registered OAuth callback through a narrowly validated forwarding alias

## Validation

- `npm test`: 221 tests passed
- production Worker deployed and real Google OAuth flow reaches the account chooser without `redirect_uri_mismatch`
- temporary OAuth test transaction removed after validation

This supersedes the closed PR #1440.