### PR TITLE
Add Favicon Manager extension (ConataApple)

### DIFF
--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "92f901a5216f60e39754a1c2d1c9d6dfb7863c12",
+  "source_commit": "740a9978c62b9c49ab97fef2a921c9658c946ea9",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -5,6 +5,6 @@
   "tags": ["favicon", "links", "ui", "icons"],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "6282b740842130b94d3c4e638e70d03cccdfa17b",
+  "source_commit": "954637cef0d155c5c93ac435a7b89f1bddca43ac",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "b00d98742bf09252ed4ed370b7f7fa5d64af55c4",
+  "source_commit": "7c2def0b1d8287488ee2805ebb0d54af31f3e0af",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "52041cd989b4b1357fd052daafbb93adfa7f4882",
+  "source_commit": "dcfd550e61ff990ef8d79c67811ab013a94cceac",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "364b4c2ce4af3a9a47989d88ebd6b8a843abd1ee",
+  "source_commit": "52041cd989b4b1357fd052daafbb93adfa7f4882",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "9b49876ceff54447ada18860aba4a42fc25259f5",
+  "source_commit": "1cb3bf2e8a5d84a6689fae0d2635d4f60edd706a",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "1fa47ec0d164be07be37bd1c22b9ee6b99d5e320",
+  "source_commit": "d797e6bf792480dce364022c69194ca6892858c6",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -2,9 +2,14 @@
   "name": "Favicon Manager",
   "short_description": "Show website favicons next to external links in Roam, with a settings panel and per-site custom icons. Based on paulovieira/roam-show-favicon.",
   "author": "ConataApple",
-  "tags": ["favicon", "links", "ui", "icons"],
+  "tags": [
+    "favicon",
+    "links",
+    "ui",
+    "icons"
+  ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "954637cef0d155c5c93ac435a7b89f1bddca43ac",
+  "source_commit": "b00d98742bf09252ed4ed370b7f7fa5d64af55c4",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "740a9978c62b9c49ab97fef2a921c9658c946ea9",
+  "source_commit": "1fa47ec0d164be07be37bd1c22b9ee6b99d5e320",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "d797e6bf792480dce364022c69194ca6892858c6",
+  "source_commit": "e079855a544ea8301d6c0a2be0cf719c202a18c9",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "26491375e74d0f89aefd761772cda01d315f98de",
+  "source_commit": "92f901a5216f60e39754a1c2d1c9d6dfb7863c12",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "7c2def0b1d8287488ee2805ebb0d54af31f3e0af",
+  "source_commit": "364b4c2ce4af3a9a47989d88ebd6b8a843abd1ee",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -1,0 +1,10 @@
+{
+  "name": "Favicon Manager",
+  "short_description": "Show website favicons next to external links in Roam, with a settings panel and per-site custom icons. Based on paulovieira/roam-show-favicon.",
+  "author": "ConataApple",
+  "tags": ["favicon", "links", "ui", "icons"],
+  "source_url": "https://github.com/ConataApple/roam-favicon-manager",
+  "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
+  "source_commit": "6282b740842130b94d3c4e638e70d03cccdfa17b",
+  "stripe_account": ""
+}

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "dcfd550e61ff990ef8d79c67811ab013a94cceac",
+  "source_commit": "26491375e74d0f89aefd761772cda01d315f98de",
   "stripe_account": ""
 }

--- a/extensions/ConataApple/favicon-manager.json
+++ b/extensions/ConataApple/favicon-manager.json
@@ -10,6 +10,6 @@
   ],
   "source_url": "https://github.com/ConataApple/roam-favicon-manager",
   "source_repo": "https://github.com/ConataApple/roam-favicon-manager.git",
-  "source_commit": "e079855a544ea8301d6c0a2be0cf719c202a18c9",
+  "source_commit": "9b49876ceff54447ada18860aba4a42fc25259f5",
   "stripe_account": ""
 }


### PR DESCRIPTION
## Favicon Manager for Roam Research

A community contribution that builds on top of the wonderful original [`roam-show-favicon`](https://github.com/paulovieira/roam-show-favicon) by **Paul Vieira (paulovieira)**.

### What it adds
- A **native Roam Depot settings panel** — the original plugin had no UI (the author listed "make the options configurable by the user" as a future improvement).
- **Per-site custom icons** — assign any image URL to any domain (e.g. `z-lib.fm=https://z-lib.fm/img/favicons/favicon.svg`).
- Tunable icon position, size, spacing, and favicon provider (duckduckgo / google / yandex).

### Attribution
All credit for the original idea and implementation goes to **Paul Vieira**. This extension is released under the same MIT license: original work © Paul Vieira 2022, modifications © ConataApple 2026. If Paul would ever like these enhancements merged back upstream, we would be delighted.

### Links
- Source: https://github.com/ConataApple/roam-favicon-manager
- Original: https://github.com/paulovieira/roam-show-favicon

Thank you for maintaining Roam Depot and for reviewing!