### PR TITLE
Update Nautilus Log: daily-plan creation, capacity bar, and Google sync

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "4db0dd13319e077f50e0b09355b1e5c07c88c1b1"
+  "source_commit": "db38cc3eaf3d19d355afde3096df1b28ee0f7375"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -1,9 +1,9 @@
 {
   "name": "Nautilus Log",
-  "short_description": "A transparent visual day planner with optional CLOCK timing, task switching, overload visibility, and a lightweight daily review.",
+  "short_description": "A visual day planner with optional Google Calendar sync, CLOCK timing, a layered capacity bar, overload visibility, and daily review.",
   "author": "404KSG",
-  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity"],
+  "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7bf19a1d482678d1f22d08bb08307b98ce2e5fd4"
+  "source_commit": "50a151a71021f11e35b6565df58b039f96af5c01"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "080d19394aa3f284725603dcf3a974581beb1309"
+  "source_commit": "7504eaab28569a1c920aa84c08854a140b5d2e69"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "5df2ae7855db34dd89221c057fb4f39117163095"
+  "source_commit": "3e7f933dd74b2949bf3f76d128854420ab753b86"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "50a151a71021f11e35b6565df58b039f96af5c01"
+  "source_commit": "0f522f46e8383d2fa480f25e3ddeaf5ea72fe3bc"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "0f522f46e8383d2fa480f25e3ddeaf5ea72fe3bc"
+  "source_commit": "41ef7075c02bb030b8e08f0e2e74edac12256941"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "db38cc3eaf3d19d355afde3096df1b28ee0f7375"
+  "source_commit": "080d19394aa3f284725603dcf3a974581beb1309"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "f5ee8467d1846404637b5abaf55a9842cfce080f"
+  "source_commit": "95190b9fb06c4cd63c6bd57601fc75babe25db76"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3e7f933dd74b2949bf3f76d128854420ab753b86"
+  "source_commit": "4db0dd13319e077f50e0b09355b1e5c07c88c1b1"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "7504eaab28569a1c920aa84c08854a140b5d2e69"
+  "source_commit": "f5ee8467d1846404637b5abaf55a9842cfce080f"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "41ef7075c02bb030b8e08f0e2e74edac12256941"
+  "source_commit": "5df2ae7855db34dd89221c057fb4f39117163095"
 }


### PR DESCRIPTION
## Summary

This PR supersedes #1441 and proposes one combined Nautilus Log update from the current Depot revision to source commit [`95190b9`](https://github.com/404KSG/roam-nautilus-log/commit/95190b9fb06c4cd63c6bd57601fc75babe25db76), including complete one-click daily-template creation and the reviewed execution-layer fixes.

### Google Calendar and Tasks

- add optional, read-only Google Calendar and Google Tasks sync
- use hosted OAuth with persistent authorization, PKCE-protected sessions, and a Roam Desktop system-browser flow
- sync only the explicitly selected Daily Note and Nautilus Plan; no background Calendar polling
- preserve local edits and user descendants during reconciliation, with an explicit force-refresh path for managed fields
- keep Calendar events fixed and Google Tasks flexible, while preserving account-aware links and source provenance
- isolate Tasks failures so Calendar sync remains available

### One-click daily planning

- one normal topbar click creates and opens a complete copy of the current managed Nautilus template: renderer root, fixed events, tasks, separators, and nested children; no intervening panel, confirmation, or manual `;;`
- always append to the local-calendar Daily Note, regardless of the page currently open; preserve existing daily blocks and the source template
- use the literal template root, fresh destination UIDs, internal-reference remapping, unchanged external references, and supported block presentation fields; retain TODO/DONE text and ownership
- locate an existing canonical or legacy plan, including empty and all-DONE plans, instead of inserting another copy; retain an explicit empty-renderer fallback only when no managed template exists
- guard writes with graph/date Web Locks, a reserved root UID, source and UID preflight checks, and complete tree readback; root presence alone is not success
- retain partial copies without deleting, overwriting, or creating a second copy; allow explicit continuation only from the same in-memory operation after revalidating written content
- preserve incomplete status across navigation, tracking updates, and reloads with a graph/date integrity receipt containing SHA-256 hashes, not template text; reload may verify or open, but cannot supplement a partial tree from a new source snapshot
- show short, actionable creation/error states instead of a false empty capacity reading or `Use ;;` button; give unsupported structures a concrete reason and a working View template action
- share the same session across both topbars, the Plan empty state, and the command; keep CLOCK/POMO and stop controls visible, and keep the lightweight launcher independent of the timing runtime
- fix the actual tooltip with wrapping, border-box sizing, viewport clamping, theme inheritance, and keyboard linkage, without redesigning the capacity bar
- keep graph/date/unload guards, bounded recovery, and cached tracking projections; do not add per-second graph queries, copy yesterday, reset DONE, copy CLOCK history, or trigger Google sync

### Execution and capacity

- add a default-off, single layered capacity gauge to the optional Execution Layer topbar
- show flexible reserve, unfinished planned demand, and elapsed capacity on one full-day time scale
- use a fixed, fully rounded `136×6px` capsule with a left-aligned `% left · planned duration` summary
- match free reserve to Roam's right-side toolbar icons (`#5c7080` sRGB) while keeping unfinished planned demand light green
- keep the capsule free of borders, shadows, decorative end structures, and track-level overload markers
- keep planned readings visible throughout completion; remove the overlaid duration cue and the 140ms layer delay
- settle both widths with the same 360ms transition and briefly emphasize the planned number for 320ms after confirmed panel completion
- keep warning text readable and unchanged; external TODO/DONE edits do not trigger confirmation, and reduced motion disables both effects
- show overload or no-slot warnings once in the exact lower text without a duplicate track marker
- place the track and summary exactly `7px` above and below the Roam topbar centerline
- keep the CLOCK/POMO timer centered on the topbar axis without compressing the gauge
- switch directly from the full gauge to a `30px` icon-only trigger when space is constrained
- keep standalone POMO stoppable from the panel in icon-only density
- ensure completing a non-focused task cannot stop the focused CLOCK or reset its Pomodoro cycle
- preserve the existing text-only capacity path when the energy-bar option is disabled

### Execution reliability and interaction

- coordinate CLOCK writes with graph-scoped native Web Locks and revalidate current records after acquiring the lock; cross-tab messages carry invalidation hints, not authoritative data
- bind Stop/Delete to the CLOCK UID selected before waiting, preserving newer CLOCKs and closed history; recheck the selected block immediately before deletion
- keep actions in the working state until writes settle, resume paused background reads, and reread actual graph state after a partially failed operation
- read current CLOCKs for task completion and background DONE reconciliation, including source-owned TODO/DONE reference chains
- display explicit next-day times instead of clamping schedules to `24:00`; share one minute-level projection between the energy bar and open panel without adding a polling loop
- preserve task-control focus and scroll position across rebuilds; support arrow/Home/End tab navigation and Escape-to-trigger
- cancel pending initialization and queued writes on unload, prevent timers or commands from restarting, and serialize rapid tracking-setting changes
- preserve CLOCK priority over standalone POMO without leaving actions stuck in the working state

Designs:
- [Capacity bar](https://github.com/404KSG/roam-nautilus-log/blob/95190b9fb06c4cd63c6bd57601fc75babe25db76/docs/plans/2026-09-07-optional-energy-bar-design.md)
- [Complete daily-template creation, integrity, and platform limits](https://github.com/404KSG/roam-nautilus-log/blob/95190b9fb06c4cd63c6bd57601fc75babe25db76/docs/plans/2026-09-10-full-template-creation-design.md)
- [Execution reliability, cancellation, and review scope](https://github.com/404KSG/roam-nautilus-log/blob/95190b9fb06c4cd63c6bd57601fc75babe25db76/docs/plans/2026-09-09-execution-refinement-design.md)

## Validation

### Current revision

- `npm test`: **371/371 passing**, including the production build and 78 managed-template tests
- `npm run build`: passing, with the existing three webpack bundle-size warnings
- `npm run test:ui`: **all four browser suites passing**
- `python3 test/real-today-plan.py`: **25/25 acceptance cases**, using the actual source reader, creation session, timing runtime, and DOM with only the low-level host graph/time faked; covers one-click complete creation in both topbars, reference/format preservation, partial continuation and reload, navigation/read failures, tooltip bounds, Chinese/dark/keyboard/narrow layouts, timer priority, midnight, and the shared command
- the original launcher, energy-bar settlement, and execution-refinement browser suites remain passing as presentation/runtime regressions; their fixture states are not treated as end-to-end creation evidence
- managed-template tests cover Nth-write failure, write-then-throw, source changes during lock/receipt/page awaits, destination edits, UID collisions, independent sessions, incomplete-state preservation, SHA-256 recovery, malformed or delayed receipts, graph/date/unload changes, native metadata normalization, and bounded tracking reads
- read-only official-CLI Datalog checks accepted the current complete template through the production reader and exposed unqualified activity metadata; regressions for that metadata and `view-type` were first red, then green. No private template text was retained
- independent **Grok 4.6 xhigh** source review: `no_confirmed_findings`; it did not rerun tests or certify live Roam behavior. Runtime source hashes matched the reviewed files; the only subsequent change removed an extra test-file EOF newline, followed by a passing 78-test rerun
- `npm audit --omit=dev --audit-level=moderate`: 0 production-dependency vulnerabilities
- Depot manifest JSON and staged `git diff --check`: passing

No production graph writes or live creation smoke test were performed for this revision. Native Desktop create behavior, extension-settings persistence across reloads, Desktop Web Locks availability, the running-CLOCK DataScript filter, and cross-client synchronization remain live-validation boundaries. Read-only schema checks and isolated browser tests do not prove those write paths. Web Locks coordinate participating contexts in the same storage partition, not separate profiles/devices or manual writers. Unsupported creation paths fail closed with explicit diagnostics. No large-graph performance claim is made.

### Earlier integration checks

Retained from previous revisions; not rerun for the latest complete-template creation update:

- `./build.sh`: passing
- production OAuth service `/health`: healthy
- production `/config`: accepted the Roam origin and rejected an untrusted origin with `403`
- hosted OAuth flow previously reached the Google account chooser without `redirect_uri_mismatch`; the temporary test transaction was removed
- real Roam Web smoke through `404KSG+roam-nautilus-log+1445`: extension identity, Pull Watch, tooltip and keyboard semantics, full and icon-only layouts, CLOCK isolation, focused completion, standalone POMO start/stop, right-sidebar placement, and default-off restoration
- verified the `160×30px` full trigger, fixed `136×6px` gauge, exact `±7px` row symmetry, centered timer, `30×30px` icon-only fallback, and no overlap with Roam search
- static Chromium validation confirmed that free reserve and the right-side toolbar reference both compute to `rgb(92, 112, 128)` (`#5c7080` sRGB); the supplied Display P3 screenshot stores that solid color near `#60707f` before profile conversion
- all temporary Roam smoke fixtures were deleted by exact UID; the unique test prefixes returned zero results after cleanup
- final browser console check: 0 errors and 0 warnings
- Depot manifest JSON and `git diff --check`: passing

The local Depot Clojure wrapper is unavailable because Clojure is not installed on this machine. The official PR workflow installs Clojure and runs the repository build in CI.

