### PR TITLE
Update Native Insert Block for long UID targeting and stale focus

### DIFF
--- a/extensions/404KSG/roam-native-insert-block.json
+++ b/extensions/404KSG/roam-native-insert-block.json
@@ -5,5 +5,5 @@
   "tags": ["block", "insert", "hover", "UI", "editing"],
   "source_url": "https://github.com/404KSG/roam-native-insert-block",
   "source_repo": "https://github.com/404KSG/roam-native-insert-block.git",
-  "source_commit": "354415dfeb2de0d2794fcb07f4e79f80f189d0b2"
+  "source_commit": "46ac98db6d3b146d3a5c3339a3b51ff0ebe89d9c"
 }


### PR DESCRIPTION
Update Native Insert Block to v0.9.3 ([46ac98db6d3b146d3a5c3339a3b51ff0ebe89d9c](https://github.com/404KSG/roam-native-insert-block/commit/46ac98db6d3b146d3a5c3339a3b51ff0ebe89d9c)).

Native owning-container `data-block-uid` now replaces last-9/candidate guessing for all five actions. Invalid or stale targets are refused. Same-window focus plus lifecycle, async, and delete-race handling are fixed.

Automated verification: Node 22.22.2, 65 distinct tests plus smoke. Rerunning that same suite reports 82.16% line coverage on runtime `extension.js`; that figure is coverage of the existing 65 tests, not additional tests. Source CI: https://github.com/404KSG/roam-native-insert-block/actions/runs/34437151843

Depot build: https://github.com/Roam-Research/roam-depot/actions/runs/34437560436 (success)
Preview publish: https://github.com/Roam-Research/roam-depot/actions/runs/34437583359 (success; privileged publish is separate from build)

Live validation, 2026-09-10, Chromium on macOS, browser automation on disposable content only. These are scoped session results, not a claim that every test passed in every environment.

- Preview `extension.js` for `404KSG+roam-native-insert-block+1446` matches reviewed SHA-256 `aa415eab929e783ea95778abde5c60086a86fb5fb83e463e237f4c36366bb589`. The developer-extension UI showed PR 1446 as RUNNING with autostart and did not expose a source-commit field.
- Shift-delete removed the exact long custom UID; an independently seeded nine-character suffix victim survived. After the old source was disabled and the page was fully reloaded, the same result held.
- Also observed: plain insert below; Alt insert above; Meta child insert with expansion; Control-wrap creating exactly one parent; combined modifiers producing no write.
- The same fixture rendered in main and in the sidebar. Sidebar Meta-child parent and order were verified. `document.activeElement` was a textarea inside the originating sidebar, not main, and a typed marker persisted in that child.
- Native own-block View as Document set `children/view-type` to `document`. The control remained visible and inserted a sibling in order.
- Two disposable pages and 27 test blocks were created across two passes. All 29 page/block UIDs and both titles were confirmed absent afterward. Only this extension's own sidebar windows were closed; existing notes and other extension settings were left untouched.
- An initial test-driver pass omitted mouse Shift and inserted one extra sibling. That sibling was recorded and removed. Explicit Shift and the post-reload retest passed.
- Limitation: in this Chromium/macOS session, a Control-left gesture produced trusted `mousedown` and `contextmenu` events but no `click`. Functional wrap still passed. Same-press `click`+`contextmenu` duplicate suppression was not reproduced live. That path is covered by `tests/actions.test.js` (`one Control press wraps the block at most once`), which calls `onMouseDown`, then `onContextMenu`, then `onClick`, and asserts exactly one create and one move. That mock test is not live evidence.

Preview instructions (this is not Marketplace Search Extensions):

1. Settings → Roam Depot → Installed (gear) → Enable developer mode
2. Open the Developer Extensions link
3. Choose Load Developer Extensions from URL
4. Enter `404KSG+roam-native-insert-block+1446`
5. Load remote extension

Use one Native Insert source at a time: disable the installed stable copy before using this developer preview, and keep the old copy installed for rollback. In this session the old stable source was disabled, PR 1446 was enabled with autostart, and one normal page reload left it RUNNING. A newer runtime init/destroy fingerprint plus post-reload deletion passed. Other extensions were not toggled.

Preview shorthand: `404KSG+roam-native-insert-block+1446`

This Depot diff only changes `extensions/404KSG/roam-native-insert-block.json` `source_commit`.
