### PR TITLE
Restore Nautilus Log daily template creation after deletion

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "95190b9fb06c4cd63c6bd57601fc75babe25db76"
+  "source_commit": "6de3272689b542d7668062f366626ecc0999df37"
 }


### PR DESCRIPTION
## Summary

This updates the published Nautilus Log pin from [`95190b9fb06c4cd63c6bd57601fc75babe25db76`](https://github.com/404KSG/roam-nautilus-log/commit/95190b9fb06c4cd63c6bd57601fc75babe25db76) to [`6de3272689b542d7668062f366626ecc0999df37`](https://github.com/404KSG/roam-nautilus-log/commit/6de3272689b542d7668062f366626ecc0999df37). Depot already carries complete one-click daily-template creation from #1445. This follow-up restores creation after the managed plan root is missing or deleted.

- a missing or deleted root is no longer treated as an empty existing plan
- a later explicit click recreates the full current template, including missed-watch recovery
- recreation captures the original graph, date, and source; reconciles a replacement plan; and refuses to proceed on read errors or incomplete receipts
- recovery does not add a second navigation step or an extra panel
- test-only Web Locks fixtures were corrected without weakening production coordination

This Depot diff changes only `extensions/404KSG/roam-nautilus-log.json` `source_commit`.

Source: https://github.com/404KSG/roam-nautilus-log/commit/6de3272689b542d7668062f366626ecc0999df37

Design: https://github.com/404KSG/roam-nautilus-log/blob/6de3272689b542d7668062f366626ecc0999df37/docs/plans/2026-09-10-template-deletion-recreation-design.md

## Validation

Local checks used the real source modules and DOM controls against a synthetic host. They are not live Roam, native Pull Watch, or installed-extension validation.

- Node 22.22.2 `npm test`: 386 passing, 0 failing
- `npm run test:ui`: all browser suites passing, including the real-button suite 41/0 plus the energy-bar, launcher, and execution-refinement suites
- JSON parse and `git diff --check`: passing

A held integrity check can still open the existing-plan panel after Escape if no popover existed yet. That is not comprehensive pending-cancel coverage.

The local Depot Clojure wrapper is unavailable because Clojure is not installed on this machine. The official PR workflow installs Clojure and runs the repository build in CI.

Preview publication is a separate privileged workflow. A successful PR build does not mean the extension is published or installed.

Preview shorthand: `404KSG+roam-nautilus-log+1447`
