### PR TITLE
Draft preview: Nautilus Log reliability and bounded popover validation

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6de3272689b542d7668062f366626ecc0999df37"
+  "source_commit": "1356f4d9fae16efe93cffb966d475a94e75856d1"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "1356f4d9fae16efe93cffb966d475a94e75856d1"
+  "source_commit": "d39fb3c19a59f17a1ce0aa5c5f6d20d4aac064ee"
 }


### PR DESCRIPTION
## Purpose

**Test preview only. Please keep this PR as a draft. Do not merge or publish this candidate to the Marketplace yet.**

**Current requested acceptance scope: the Nautilus execution panel repair. Google authorization, Calendar end-to-end validation, and Cloudflare deployment are not prerequisites for this panel delivery.** Earlier Calendar-related work remains in the source history; it must not be confused with a requirement to access the user's Google account to test the panel.

This PR changes only `source_commit` for `404KSG/roam-nautilus-log`. The name, description, tags, author, and source URLs are unchanged.

- Published baseline: `6de3272689b542d7668062f366626ecc0999df37`
- Previous preview: `1356f4d9fae16efe93cffb966d475a94e75856d1`
- Updated candidate: `d39fb3c19a59f17a1ce0aa5c5f6d20d4aac064ee`
- [Full source comparison](https://github.com/404KSG/roam-nautilus-log/compare/6de3272689b542d7668062f366626ecc0999df37...d39fb3c19a59f17a1ce0aa5c5f6d20d4aac064ee)
- [Changes since the previous preview](https://github.com/404KSG/roam-nautilus-log/compare/1356f4d9fae16efe93cffb966d475a94e75856d1...d39fb3c19a59f17a1ce0aa5c5f6d20d4aac064ee)

The source commit is publicly available. This update requests a new build of the existing PR preview, not a Marketplace release.

## Candidate changes

The candidate retains the earlier topbar, Calendar recovery, historical CLOCK, Plan watch, and rendering fixes.

The latest revision addresses an unbounded wait for `requestAnimationFrame` before Plan validation. It keeps the immediate checking shell and the normal frame-then-task path, but adds an independent 50ms timer fallback. Each wait owns its callbacks and settles once; cancellation and late callbacks cannot take over a newer wait. All fresh-data, root, receipt, date, graph, and action guards remain in place. The timer is a scheduling budget, not a 50ms wall-clock guarantee on a blocked or throttled event loop.

The tests now take time-sensitive snapshots within one JavaScript turn, track timer cancellation separately from forced late delivery, cover held-frame cancellation, and report inapplicable cases as skipped rather than passed.

## Evidence and limits

Local validation for this revision:

- 439 Node/Worker tests passed.
- All four browser fixture suites passed. The real-source/synthetic-host suite reports **48 passed, 15 skipped, 0 failed**, with consistent results across three consecutive runs and another full-suite run. Earlier totals included inapplicable launcher cases; the new accounting does not treat those as coverage.
- Eight performance-tool tests passed.
- Independent code review found no blocking product issue. The final test review closed the timing, cancellation, late-callback, and skip-accounting notes.
- Expected JavaScript bundle SHA-256: `f6d621aa70d3aed469bdf9de0fc412a9d3d72a4b5a145da7c7103ff1add47ad2`.

The previous preview was installed through the official PR ShortHand and verified after reload. Controlled live fixtures exercised native Plan creation, nonempty task rows, CLOCK Start/Stop, and SCI rendering; the temporary graph fixtures were cleaned up. Corrected measurements still showed roughly 1.16 seconds to complete panel readiness, which prompted this revision.

The updated preview has now been verified from the **running script source**, whose SHA-256 matches the expected bundle, and again after a full reload. The previous Marketplace installation remains disabled, with one preview runtime and the original non-secret settings preserved.

In a controlled live Plan with eight task rows, ten valid trusted-click samples showed median event-to-shell latency of **11.4ms**, full DOM readiness of **197.8ms** (P95 **213ms**), and close latency of **9.6ms**. The previous preview's comparable recorded readiness was about 1160ms; this was not a same-window A/B test, so no general speedup ratio is claimed.

A final six-row pass captured five matched opening EventTiming entries after correcting the observer threshold and nested-target matching. Median DOM readiness was **217.9ms**, while median click-to-next-paint duration was **1032ms** and handler processing was **2.4ms**. The browser's presentation delay therefore remains unresolved; DOM readiness is not a full-content paint timestamp or site-wide INP. Closing timestamps from that last pass were contaminated by waiting for EventTiming delivery and are not used as DOM-close latency.

A later user-operated click, captured during browser handoff without another automated click, reached its next paint in **24ms**: input delay **6ms**, processing **4ms**, presentation delay **14ms**. This is one human sample, not a statistical or site-wide INP claim. Its original content-ready field was invalid because a loose text predicate accepted the checking shell. That field was discarded, not reported as a 9ms content-ready result. The corrected strict predicate was self-tested, then three separate automated samples verified **six task rows and twelve enabled actions in approximately 141–145ms**. Those automated samples do not replace the human sample.

The roughly one-second idle-first automation delay also reproduces on a neutral page without Nautilus. It must not be attributed to this panel's business logic or used to expand this panel request into a browser-runtime or Google-integration project.

Live checks also exercised native Plan creation, CLOCK Start/Stop, task completion followed by a Roam-checkbox reversal to TODO, standalone POMO Start/Stop without changing its configured duration, and SCI rendering. All 23 owned temporary graph UIDs were read back as absent after cleanup. The CLOCK deletion-confirmation cancellation check is distinct from cancellation of an opening validation wait; the latter has local integration-test coverage.

Isolated Calendar integration passed against the real Roam backend using the running production reconciler, its default adapters, native Web Locks, and temporary graph-backed JSON state/journal blocks. Synthetic events exercised idempotency after reconstruction, field updates and moves, preservation of a simulated user descendant, cancellation of an unmodified managed tree, recovery after a persisted journal but before graph creation, and concurrent reconcilers without duplicate parents. All 21 owned Calendar fixture UIDs were verified absent after cleanup. This did not use or change the real extension mapping, credentials, or Google APIs.

Opening-validation cancellation also passed through a real Roam opening click followed by a controlled synthetic Escape while the panel was still busy: no full query and no resurrection. Three attempted native double-click trials did not establish a valid pre-validation click pair and are not counted as proof of rapid native cancellation. The final pass cleaned all 18 of its fixture UIDs and closed the test window.

**Real Google synchronization and OAuth deployment verification are outside the clarified panel scope. No claim of Google end-to-end success is made, and those checks do not block this panel repair.** The user's separately established connection must not be disconnected or modified as part of panel cleanup.

Before this PR is marked ready:

- [x] Official build and preview publication for this revision succeed, with the expected bundle hash.
- [x] Reload `404KSG+roam-nautilus-log+1448` and verify the updated code identity, one runtime, and preserved settings.
- [x] Repeat event-based, nonempty-panel DOM-readiness measurements without counting automation round trips.
- [x] Capture correctly matched EventTiming separately from DOM readiness.
- [x] Complete the scoped synthetic-provider/real-Roam integration checks and verify fixture cleanup.
- [x] Record the user-operated first-paint sample separately from strict nonempty-content measurements and automation-environment limitations.
- [x] Cover pending-open cancellation and late-callback ownership through deterministic real-source UI tests; retain the stated limits of live native double-click sampling.

No Google login, additional Calendar synchronization, or Cloudflare deployment is required to complete the panel request.

No merge, auto-merge, reviewer request, Google authorization, OAuth deployment, or Marketplace publication is requested by this draft.
