### PR TITLE
Nautilus Log: responsive execution panel with safe validation

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6de3272689b542d7668062f366626ecc0999df37"
+  "source_commit": "a586b71979b4075f93c6f482b5ff896bd246243a"
 }


### PR DESCRIPTION
## Scope

This is the focused **execution-panel repair** for Nautilus Log, submitted for review. It changes only the extension manifest's `source_commit`.

- Published baseline: `6de3272689b542d7668062f366626ecc0999df37`
- Reviewed candidate: `a586b71979b4075f93c6f482b5ff896bd246243a`
- [Source comparison](https://github.com/404KSG/roam-nautilus-log/compare/6de3272689b542d7668062f366626ecc0999df37...a586b71979b4075f93c6f482b5ff896bd246243a)
- Source scope: **16 files**, including the panel, necessary shared helpers, tests, and documentation.

The candidate was extracted on the published baseline. It does not include the separate Calendar WAL, OAuth, chart CLOCK cache, keyword/layout, or Tidy changes from the larger candidate in #1448. Those changes remain preserved on their original source branch. **Please keep #1448 as a separate draft; this PR does not replace its preview or request that it be merged.**

## Panel changes

- Show an immediate, non-actionable checking shell before authoritative validation.
- Give rendering a frame opportunity, with an independent 50ms scheduling fallback so a stalled animation frame cannot leave the panel checking indefinitely.
- Keep each deferred wait's ownership and single-settlement rules; late callbacks cannot take over a reopened panel.
- Close without graph reads and prevent dismissed openings from reappearing.
- Preserve Primary/root, receipt, date, graph, and fresh-row checks, including safe whole-root recreation.
- Preserve action nodes, focus, and scroll when structure is unchanged.
- Expire Recent items on the bounded time lane and coalesce Plan-watch reads.

The 50ms value is a scheduling budget, not a wall-clock or paint guarantee. Closing prevents reopening; it does not abort a graph read that has already started.

## Validation of this exact candidate

- Targeted Node tests: **91 passed, 0 failed** (published-baseline run: 82 passed).
- Full Node/Worker suite: **395 passed, 0 failed, 0 skipped**.
- All **four browser fixture suites passed**; the real-source/synthetic-host suite reports **48 passed, 15 inapplicable cases skipped, 0 failed**.
- Performance-tool tests: **8 passed, 0 failed**.
- Build succeeded; the same category of webpack size warnings exists on the baseline.
- Whitespace checks passed.
- Independent correctness and scope reviews found no blocking issue. File hashes and the complete patch were rechecked after review.

Expected JavaScript bundle SHA-256:

```text
f372428d91e34c798983ca8d0f4ed2d402862b2ce7126fb0b24bf740a014d29a
```

These are fresh results from the focused candidate. Test counts and live timings from the larger `d39fb3c` candidate are **not** used as evidence for this build.

## Review and deployment boundaries

- Official [Build #34681509506](https://github.com/Roam-Research/roam-depot/actions/runs/34681509506) and [Preview Publish #34681532818](https://github.com/Roam-Research/roam-depot/actions/runs/34681532818) both succeeded. Independent verification confirmed the correct PR/head association and that the downloaded official JavaScript matches the expected SHA-256 above byte for byte.
- The [official bot comment](https://github.com/Roam-Research/roam-depot/pull/1449#issuecomment-5644541059) confirms the preview ShortHand: `404KSG+roam-nautilus-log+1449`.
- This exact focused bundle has not been installed in the live Roam graph. The local browser suites use the real source with a controlled host.
- Updating a normal installation from the published baseline is different from replacing the broader `d39fb3c` development preview. Do not blindly downgrade that preview's independent Calendar metadata or overwrite an existing user connection.
- Google authorization, Calendar end-to-end testing, and Cloudflare deployment are not prerequisites for this panel request. No Google data or credentials were accessed as part of this extraction.
- Official artifact verification is complete; this PR is ready for maintainer review. No automatic merge, Marketplace release, or replacement of an existing preview is requested.
