### PR TITLE
Add Input Agent Bridge (draft preview)

### DIFF
--- a/extensions/404KSG/input-agent-bridge.json
+++ b/extensions/404KSG/input-agent-bridge.json
@@ -1,0 +1,8 @@
+{
+  "name": "Input Agent Bridge",
+  "short_description": "Preview: send explicitly selected editor text to a local Pi session. Desktop loading unverified.",
+  "author": "404KSG",
+  "source_url": "https://github.com/404KSG/input-agent-bridge",
+  "source_repo": "https://github.com/404KSG/input-agent-bridge.git",
+  "source_commit": "f29e6ea718a220222ffaee2eb81b4aa9433629ee"
+}

--- a/extensions/404KSG/input-agent-bridge.json
+++ b/extensions/404KSG/input-agent-bridge.json
@@ -4,5 +4,5 @@
   "author": "404KSG",
   "source_url": "https://github.com/404KSG/input-agent-bridge",
   "source_repo": "https://github.com/404KSG/input-agent-bridge.git",
-  "source_commit": "788d664d880551ec5deb3fb0e90281ef30544c40"
+  "source_commit": "cbeb31185aaa06652776e699a8b4d921286aeb4d"
 }

--- a/extensions/404KSG/input-agent-bridge.json
+++ b/extensions/404KSG/input-agent-bridge.json
@@ -4,5 +4,5 @@
   "author": "404KSG",
   "source_url": "https://github.com/404KSG/input-agent-bridge",
   "source_repo": "https://github.com/404KSG/input-agent-bridge.git",
-  "source_commit": "f29e6ea718a220222ffaee2eb81b4aa9433629ee"
+  "source_commit": "788d664d880551ec5deb3fb0e90281ef30544c40"
 }


### PR DESCRIPTION
# Add Input Agent Bridge (draft preview)

This draft adds metadata for `404KSG/input-agent-bridge`.

The source is a preview plugin: you keep writing in the original editor, explicitly choose text and an existing local Pi session, then send through a loopback connector. Overlay labels are currently in Chinese.

Controlled Roam Desktop validation is in progress; offline checks alone do not establish readiness. Opening this draft PR is not Marketplace publication and not a Desktop install.

This PR changes only:

- `extensions/404KSG/input-agent-bridge.json`

`source_commit` is the public export commit `cbeb31185aaa06652776e699a8b4d921286aeb4d`, not an internal history SHA.

The source repository has not chosen a distribution license. Do not assume MIT or other open-source terms.

Please keep this pull request as a draft.