### PR TITLE
Nautilus Log: calendar reliability, chart lifecycle, and safe Tidy

### DIFF
--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "6de3272689b542d7668062f366626ecc0999df37"
+  "source_commit": "3928c75559768364196b35d4ee5af8cb4e660ba6"
 }

--- a/extensions/404KSG/roam-nautilus-log.json
+++ b/extensions/404KSG/roam-nautilus-log.json
@@ -5,5 +5,5 @@
   "tags": ["time-blocking", "time-tracking", "tasks", "planning", "productivity", "calendar"],
   "source_url": "https://github.com/404KSG/roam-nautilus-log",
   "source_repo": "https://github.com/404KSG/roam-nautilus-log.git",
-  "source_commit": "3928c75559768364196b35d4ee5af8cb4e660ba6"
+  "source_commit": "dddf03f44f3c3559625842a2e19df39a687fefad"
 }


### PR DESCRIPTION
## Summary

Update Nautilus Log to source commit `db88722acd3b75fdb1a3dfde166d72c4a33831a0`.

This is the consolidated Nautilus Log update. It includes the panel baseline from #1449 and the independently reviewed plugin reliability and performance work. It supersedes #1449 and the earlier draft #1448, both now closed so that only this Nautilus Log update remains active. Historical source branches are retained.

### Changes

- Calendar sync: fail-closed mapping and journal parsing, stable managed UIDs, write-ahead recovery, ownership checks, and preservation of local edits.
- Calendar/Tasks reads: bounded concurrency, connection-scoped metadata caching, pagination cycle and budget checks, and cancellation-generation isolation. Active Tasks retain their existing date-filter compatibility behavior.
- Graph reads: reuse duplicate reads only within a synchronous, non-yielding interval; invalidate before relying on reads after asynchronous work. Preserve write-time checks and no-op state persistence.
- CLOCK charts: explicit historical-owner coverage, owner-level TTL/LRU caching, and targeted invalidation.
- Renderer: subscription rebinding across provider generations, rejection of stale callbacks, reference-only update delivery, and last-good state for unavailable reads.
- Tidy: serialized operations, guarded writes, safe Undo-token handling, partial/unknown failure reporting, and post-write checks.
- SVG labels: reuse translated layout results and skip unused fallback work.
- OAuth Worker source: await asynchronous route handlers so rejections reach the existing sanitized error response. No Worker deployment is included.
- Daily Note tree reads prefer a synchronous reverse `data.pull` (`:block/_page` plus `:block/_children`) and fall back to the existing Datalog query when pull is missing, thenable, unreadable, or reverse fields are absent. Present but malformed `:block/string`, `:block/order`, or parent uid values are rejected as an unreadable tree; they are not dropped or ignored. Popup and Tidy share that Daily read so they no longer repeat the same work.
- Direct child outline reads (`readChildren`) prefer a synchronous `data.pull` of `:block/children` (`uid` / `string` / `order` / `open`) and fall back to the existing Datalog query when pull is missing, thenable, unreadable, the parent uid does not match, or the children field is absent. Missing `:block/open` still means false. Tidy, Calendar mapping, and LOGBOOK drawer confirmation keep the same filter/sort contract.

Only `source_commit` changes in the Depot manifest.

## Review and validation

The initial 32-file reliability update received separate final data-safety and scope/renderer reviews, followed by an independent verification run. Neither review found a mandatory fix. The four-file loading-UI follow-up was reproduced before the fix and reviewed locally; after that fix the checks were:

- **538 passing Node/Worker tests**, zero failures.
- **Four local headless UI suites**, all successful. The execution-panel suite reported **48 passed, 15 intentional skips, zero failures**.
- **8 passing performance-tool unit tests**.
- Regression probes for late renderer callbacks and cancelled reads incorrectly adopting a new operation's generation.

The Daily reverse-page pin (`1aee41eaff80fc9dcfeb00ef548db51df79003c2`) received a fresh local-gate review and an independent verification run. Neither found a mandatory fix. Independent results:

- **583 passing Node/Worker tests**, zero failures.
- **Four local headless UI suites**, all successful. The execution-panel suite reported **48 passed, 15 intentional skips, zero failures**.
- **8 passing performance-tool unit tests**.
- The original NaN-Primary probe now fail-closes on both the reverse-pull path and the legacy Datalog path.

This pin (`db88722acd3b75fdb1a3dfde166d72c4a33831a0`) received a fresh local-gate review and an independent verification run. Neither found a mandatory fix. Independent results:

- **606 passing Node/Worker tests**, zero failures.
- **Four local headless UI suites**, all successful. The execution-panel suite reported **48 passed, 15 intentional skips, zero failures**.
- **8 passing performance-tool unit tests**.
- Daily NaN-Primary fail-closed behavior remains green on this tree.

Current locally rebuilt bundle SHA-256:

`e1e63da24845126dfc32d306f2ae4672a89bb5b3e0483bb700895ab5e30539c3`

Source comparisons:

- [This update relative to the panel baseline](https://github.com/404KSG/roam-nautilus-log/compare/a586b71979b4075f93c6f482b5ff896bd246243a...db88722acd3b75fdb1a3dfde166d72c4a33831a0)
- [Full update relative to the current Depot pin](https://github.com/404KSG/roam-nautilus-log/compare/6de3272689b542d7668062f366626ecc0999df37...db88722acd3b75fdb1a3dfde166d72c4a33831a0)

## Evidence limits

Tests use production modules with synthetic graph/network adapters and local UI harnesses. No real Google sync was run. This children-pull pin has not yet been live-tested as a whole plugin.

On the previous official `1aee41e` preview, six real AND-ready popup samples had a median of 151.4 ms before that pin and 16.2 ms after it. That is six samples on that graph, not a claim for every graph or every open.

A prior live read-only A/B of one real Daily tree query measured about 134–150 ms on the old Datalog path versus about 1.7 ms on reverse pull, with 118 tuples identical. That is a query-level comparison, not a whole-plugin speedup, and it is not a 72× claim.

Old Tidy no-op child Datalog was about 114.9 ms (lock about 115.1 ms). A candidate primitive read-only children pull plus projection was about 0.25 ms on 24 rows. That primitive is not the new Tidy runtime total, and this update does not claim that live Tidy is already faster.

Measured operation counts are not live latency claims: unchanged 24-event reconciliation reduced block reads from 264 to 97 and child-list reads from 96 to 49, excluding additional runtime Plan-identity reads. Label-layout savings are sub-millisecond in local Node tests, not a demonstrated chart-stutter fix.

Known limits remain: in-flight host writes cannot be rolled back atomically; Calendar and Tidy use different locks; silent renderer changes may wait for the next poll; cross-connection pagination and sibling network requests need further hardening. Ambiguous legacy journals remain fail-closed rather than being guessed or erased.

Submitting this PR does not deploy the OAuth Worker or modify any user's Google connection. The earlier source pin passed Depot CI. Checks for the latest source pin are tracked on this PR; local test results do not imply a merge, installation, or OAuth Worker deployment.

## Follow-up: remove the checking-message flash

Commit `dddf03f44f3c3559625842a2e19df39a687fefad` replaces the text-only checking screen with static panel chrome and skeleton rows. The topbar also stays stable while the open panel validates. The loading chrome is decorative: it exposes no buttons or task rows. `aria-busy` and an accessible status label remain. No validation, bounded scheduling, cancellation, or fresh-row checks were removed.

The regression was reproduced on an already-ready Plan. Updated browser assertions failed before the fix and now pass. All 538 Node/Worker tests, four UI suites (including 48 passing execution-panel cases and 15 intentional skips), and eight performance-tool unit tests passed again. English/light and Chinese/dark loading states were also checked at desktop and narrow widths. These are local synthetic tests, not a live Roam installation.

## Follow-up: Daily reverse-page pull

Commit `1aee41eaff80fc9dcfeb00ef548db51df79003c2` replaces the slow Daily Datalog tree query with a synchronous reverse-page pull. The original query remains as a conservative fallback when pull is missing, thenable, unreadable, or reverse fields are absent. Present malformed string, order, and parent-uid values are rejected rather than ignored. Popup and Tidy share the same Daily read; that only removes duplicate work.

On the official `1aee41e` preview, six real AND-ready popup samples had a median of 151.4 ms before that pin and 16.2 ms after it. That does not represent every graph or every open.

## Follow-up: Tidy `readChildren` pull

Commit `db88722acd3b75fdb1a3dfde166d72c4a33831a0` prefers a synchronous children pull for direct outline reads, with a conservative fallback to the original Datalog query. The existing filter/sort contract is unchanged. This remains a Draft preview. Live Tidy runtime on this pin is not claimed here.
